### PR TITLE
docs: add TSDoc to document types

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -1,7 +1,7 @@
 import { AnyRegularField, GroupField, SliceZone } from "./fields";
 
 /**
- * Alternate Language to query by
+ * Document metadata for a translation of a Prismic document.
  */
 interface AlternateLanguage {
 	id: string;
@@ -27,9 +27,9 @@ export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 	alternate_languages: AlternateLanguage[];
 }
 /**
- * Prismic Documents are instances of CustomTypes.
+ * A Prismic document served through REST API v2.
  * 
- * More details on Custom Types: {@link https://prismic.io/docs/core-concepts/custom-types}
+ * More details on Custom Types: {@link https://prismic.io/docs/technologies/introduction-to-the-content-query-api}
  */
 export interface PrismicDocument<
 	DataInterface = Record<string, AnyRegularField | GroupField | SliceZone>,

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,12 +1,17 @@
 import { AnyRegularField, GroupField, SliceZone } from "./fields";
 
+/**
+ * Alternate Language to query by
+ */
 interface AlternateLanguage {
 	id: string;
 	uid?: string;
 	type: string;
 	lang: string;
 }
-
+/**
+ * Metadata for Prismic Document
+ */
 export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 	id: string;
 	uid: string | null;
@@ -21,7 +26,11 @@ export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 	lang: LangEnum;
 	alternate_languages: AlternateLanguage[];
 }
-
+/**
+ * Prismic Documents are instances of CustomTypes.
+ * 
+ * More details on Custom Types: {@link https://prismic.io/docs/core-concepts/custom-types}
+ */
 export interface PrismicDocument<
 	DataInterface = Record<string, AnyRegularField | GroupField | SliceZone>,
 	TypeEnum = string,


### PR DESCRIPTION
Adding more detailed comments to `document.ts`

### Note
I think it would be valuable to have what a `document` is in Prismic in the documentation. Would have been nice to link to it. For now, I'm linking the `CustomTypes` docs in the mean time.


https://github.com/prismicio/prismic-types/issues/8