### PR TITLE
feat: add IsEmpty generic to emptyable field types

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -297,7 +297,8 @@ export type RichTextField = RTNode[];
  *
  * @see {@link ImageField} for a full Image field type.
  */
-export type ImageFieldImage = FilledImageFieldImage | EmptyImageFieldImage;
+export type ImageFieldImage<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true ? EmptyImageFieldImage : FilledImageFieldImage;
 
 export interface FilledImageFieldImage {
 	url: string;
@@ -310,10 +311,10 @@ export interface FilledImageFieldImage {
 }
 
 export interface EmptyImageFieldImage {
-	url: null;
-	dimensions: null;
-	alt: null;
-	copyright: null;
+	url?: null;
+	dimensions?: null;
+	alt?: null;
+	copyright?: null;
 }
 
 /**
@@ -321,8 +322,14 @@ export interface EmptyImageFieldImage {
  *
  * @see Image field documentation: {@link https://prismic.io/docs/core-concepts/image}
  */
-export type ImageField<ThumbnailNames extends string = string> =
-	ImageFieldImage & Record<ThumbnailNames, ImageFieldImage>;
+export type ImageField<
+	ThumbnailNames extends string = string,
+	IsEmpty extends boolean = boolean,
+> = ImageFieldImage<IsEmpty> &
+	Record<
+		Exclude<ThumbnailNames, keyof ImageFieldImage>,
+		ImageFieldImage<IsEmpty>
+	>;
 
 // Links
 /**
@@ -392,9 +399,10 @@ export type RelationField<
 	TypeEnum = string,
 	LangEnum = string,
 	DataInterface = never,
-> =
-	| FilledLinkToDocumentField<TypeEnum, LangEnum, DataInterface>
-	| EmptyLinkField<LinkType.Document>;
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true
+	? EmptyLinkField<LinkType.Document>
+	: FilledLinkToDocumentField<TypeEnum, LangEnum, DataInterface>;
 
 /**
  * Link Field
@@ -403,18 +411,21 @@ export type LinkField<
 	TypeEnum = string,
 	LangEnum = string,
 	DataInterface = never,
-> =
-	| RelationField<TypeEnum, LangEnum, DataInterface>
-	| FilledLinkToWebField
-	| LinkToMediaField
-	| EmptyLinkField<LinkType.Any>;
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true
+	? EmptyLinkField<LinkType.Any>
+	:
+			| RelationField<TypeEnum, LangEnum, DataInterface>
+			| FilledLinkToWebField
+			| LinkToMediaField;
 
 /**
  * Link field that points to media
  */
-export type LinkToMediaField =
-	| FilledLinkToMediaField
-	| EmptyLinkField<LinkType.Media>;
+export type LinkToMediaField<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true
+		? EmptyLinkField<LinkType.Media>
+		: FilledLinkToMediaField;
 
 // Simple Fields
 
@@ -423,40 +434,50 @@ export type LinkToMediaField =
  *
  * More details: {@link https://prismic.io/docs/core-concepts/date}
  */
-export type DateField = string | null;
+export type DateField<IsEmpty extends boolean = boolean> = IsEmpty extends true
+	? null
+	: string;
 
 /**
  * Simple Timestamp Field
  */
-export type TimestampField = string | null;
+export type TimestampField<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true ? null : string;
 
 /**
  * A Color field.
  *
  * More details: {@link https://prismic.io/docs/core-concepts/color}
  */
-export type ColorField = `#${string}` | null;
+export type ColorField<IsEmpty extends boolean = boolean> = IsEmpty extends true
+	? null
+	: `#${string}`;
 
 /**
  * A Number field
  *
  * More details: {@link https://prismic.io/docs/core-concepts/number}
  */
-export type NumberField = number | null;
+export type NumberField<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true ? null : number;
 
 /**
  * A Key text field
  *
  * More details: {@link https://prismic.io/docs/core-concepts/key-text}
  */
-export type KeyTextField = string | null;
+export type KeyTextField<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true ? null : string;
 
 /**
  * A Select field
  *
  * More details: {@link https://prismic.io/docs/core-concepts/select}
  */
-export type SelectField<Enum = string> = Enum | null;
+export type SelectField<
+	Enum = string,
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true ? null : Enum;
 
 /**
  * A Boolean field.
@@ -478,8 +499,9 @@ export enum EmbedType {
  *
  * More details: {@link https://prismic.io/docs/core-concepts/embed}
  */
-export type EmbedField =
-	| {
+export type EmbedField<IsEmpty extends boolean = boolean> = IsEmpty extends true
+	? EmptyObjectField
+	: {
 			url: string;
 			width?: number | null;
 			height?: number | null;
@@ -499,20 +521,20 @@ export type EmbedField =
 			thumbnail_height: number | null;
 
 			html: string | null;
-	  }
-	| EmptyObjectField;
+	  };
 
 /**
  * A Geopoint field.
  *
  * More details: {@link https://prismic.io/docs/core-concepts/geopoint}
  */
-export type GeoPointField =
-	| {
-			latitude: number;
-			longitude: number;
-	  }
-	| EmptyObjectField;
+export type GeoPointField<IsEmpty extends boolean = boolean> =
+	IsEmpty extends true
+		? EmptyObjectField
+		: {
+				latitude: number;
+				longitude: number;
+		  };
 
 // Complex
 /**
@@ -532,14 +554,19 @@ export type GroupField<
  *
  * @see More details: {@link https://prismic.io/docs/core-concepts/integration-fields-setup}
  */
-export type IntegrationFields<Blob = unknown> = {
-	id: string;
-	title?: string;
-	description?: string;
-	image_url?: string;
-	last_update: number;
-	blob: Blob;
-} | null;
+export type IntegrationFields<
+	Blob = unknown,
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true
+	? null
+	: {
+			id: string;
+			title?: string;
+			description?: string;
+			image_url?: string;
+			last_update: number;
+			blob: Blob;
+	  };
 
 /**
  * Slice - Sections of your website

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -39,7 +39,8 @@ export interface FilledMinimalLinkToMediaField {
  */
 export type RelationField<
 	ExtendedLinkToDocumentField extends FilledMinimalLinkToWebField = FilledMinimalLinkToWebField,
-> = ExtendedLinkToDocumentField | EmptyLinkField;
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true ? EmptyLinkField : ExtendedLinkToDocumentField;
 
 /**
  * Link Field
@@ -48,15 +49,18 @@ export type LinkField<
 	ExtendedLinkToDocumentField extends FilledMinimalLinkToDocumentField = FilledMinimalLinkToDocumentField,
 	ExtendedLinkToWebField extends FilledMinimalLinkToWebField = FilledMinimalLinkToWebField,
 	ExtendedLinkToMediaField extends FilledMinimalLinkToMediaField = FilledMinimalLinkToMediaField,
-> =
-	| ExtendedLinkToDocumentField
-	| ExtendedLinkToWebField
-	| ExtendedLinkToMediaField
-	| EmptyLinkField;
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true
+	? EmptyLinkField
+	:
+			| ExtendedLinkToDocumentField
+			| ExtendedLinkToWebField
+			| ExtendedLinkToMediaField;
 
 /**
  * Link field that points to media
  */
 export type LinkToMediaField<
 	ExtendedLinkToMediaField extends FilledMinimalLinkToMediaField = FilledMinimalLinkToMediaField,
-> = ExtendedLinkToMediaField | EmptyLinkField;
+	IsEmpty extends boolean = boolean,
+> = IsEmpty extends true ? EmptyLinkField : ExtendedLinkToMediaField;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds an `IsEmpty` generic to field types that can be empty. For example, a Select field can be empty which returns `null` rather than a `String`.

In the following example, `IsEmpty` is the second generic.

```typescript
import * as prismicT from '@prismicio/types'

type MyField = prismicT.SelectField<"Option 1" | "Option 2", true>
// MyField === null
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦮
