### PR TITLE
fix: prevent compatibility issues with enum types

### DIFF
--- a/src/customType.ts
+++ b/src/customType.ts
@@ -90,24 +90,24 @@ export type CustomTypeModelFieldForGroup =
 /**
  * Type identifier for a Custom Type field.
  */
-export enum CustomTypeModelFieldType {
-	Boolean = "Boolean",
-	Color = "Color",
-	Date = "Date",
-	Embed = "Embed",
-	GeoPoint = "GeoPoint",
-	Group = "Group",
-	Image = "Image",
-	IntegrationFields = "IntegrationFields",
-	Link = "Link",
-	Number = "Number",
-	Select = "Select",
-	Slices = "Slices",
-	StructuredText = "StructuredText",
-	Text = "Text",
-	Timestamp = "Timestamp",
-	UID = "UID",
-}
+export const CustomTypeModelFieldType = {
+	Boolean: "Boolean",
+	Color: "Color",
+	Date: "Date",
+	Embed: "Embed",
+	GeoPoint: "GeoPoint",
+	Group: "Group",
+	Image: "Image",
+	IntegrationFields: "IntegrationFields",
+	Link: "Link",
+	Number: "Number",
+	Select: "Select",
+	Slices: "Slices",
+	StructuredText: "StructuredText",
+	Text: "Text",
+	Timestamp: "Timestamp",
+	UID: "UID",
+} as const;
 
 /**
  * A Boolean Custom Type field.
@@ -115,7 +115,7 @@ export enum CustomTypeModelFieldType {
  * More details: {@link https://prismic.io/docs/core-concepts/boolean}
  */
 export interface CustomTypeModelBooleanField {
-	type: CustomTypeModelFieldType.Boolean;
+	type: typeof CustomTypeModelFieldType.Boolean;
 	config: {
 		label: string;
 	};
@@ -127,7 +127,7 @@ export interface CustomTypeModelBooleanField {
  * More details: {@link https://prismic.io/docs/core-concepts/color}
  */
 export interface CustomTypeModelColorField {
-	type: CustomTypeModelFieldType.Color;
+	type: typeof CustomTypeModelFieldType.Color;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -140,7 +140,7 @@ export interface CustomTypeModelColorField {
  * More details: {@link https://prismic.io/docs/core-concepts/date}
  */
 export interface CustomTypeModelDateField {
-	type: CustomTypeModelFieldType.Date;
+	type: typeof CustomTypeModelFieldType.Date;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -153,7 +153,7 @@ export interface CustomTypeModelDateField {
  * More details: {@link https://prismic.io/docs/core-concepts/embed}
  */
 export interface CustomTypeModelEmbedField {
-	type: CustomTypeModelFieldType.Embed;
+	type: typeof CustomTypeModelFieldType.Embed;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -166,7 +166,7 @@ export interface CustomTypeModelEmbedField {
  * More details: {@link https://prismic.io/docs/core-concepts/geopoint}
  */
 export interface CustomTypeModelGeoPointField {
-	type: CustomTypeModelFieldType.GeoPoint;
+	type: typeof CustomTypeModelFieldType.GeoPoint;
 	config: {
 		label: string;
 	};
@@ -185,7 +185,7 @@ export interface CustomTypeModelGroupField<
 		CustomTypeModelFieldForGroup
 	>,
 > {
-	type: CustomTypeModelFieldType.Group;
+	type: typeof CustomTypeModelFieldType.Group;
 	config: {
 		label: string;
 		fields: Fields;
@@ -200,7 +200,7 @@ export interface CustomTypeModelGroupField<
 export interface CustomTypeModelImageField<
 	ThumbnailNames extends string = string,
 > {
-	type: CustomTypeModelFieldType.Image;
+	type: typeof CustomTypeModelFieldType.Image;
 	config: {
 		label: string;
 		constraint: CustomTypeModelImageConstraint | Record<string, never>;
@@ -234,7 +234,7 @@ export interface CustomTypeModelImageThumbnail<Name extends string = string>
  * More details: {@link https://prismic.io/docs/core-concepts/integration-fields}
  */
 export interface CustomTypeModelIntegrationFieldsField {
-	type: CustomTypeModelFieldType.IntegrationFields;
+	type: typeof CustomTypeModelFieldType.IntegrationFields;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -247,10 +247,10 @@ export interface CustomTypeModelIntegrationFieldsField {
  *
  * More details: {@link https://prismic.io/docs/core-concepts/link-content-relationship}
  */
-export enum CustomTypeModelLinkSelectType {
-	Document = "document",
-	Media = "media",
-}
+export const CustomTypeModelLinkSelectType = {
+	Document: "document",
+	Media: "media",
+} as const;
 
 /**
  * A Content Relationship Custom Type field.
@@ -261,11 +261,11 @@ export interface CustomTypeModelContentRelationshipField<
 	CustomTypeIDs extends string = string,
 	Tags extends string = string,
 > {
-	type: CustomTypeModelFieldType.Link;
+	type: typeof CustomTypeModelFieldType.Link;
 	config: {
 		label: string;
 		placeholder?: string;
-		select: CustomTypeModelLinkSelectType.Document;
+		select: typeof CustomTypeModelLinkSelectType.Document;
 		customtypes?: readonly CustomTypeIDs[];
 		tags?: readonly Tags[];
 	};
@@ -277,7 +277,7 @@ export interface CustomTypeModelContentRelationshipField<
  * More details: {@link https://prismic.io/docs/core-concepts/link-content-relationship}
  */
 export interface CustomTypeModelLinkField {
-	type: CustomTypeModelFieldType.Link;
+	type: typeof CustomTypeModelFieldType.Link;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -292,11 +292,11 @@ export interface CustomTypeModelLinkField {
  * More details: {@link https://prismic.io/docs/core-concepts/link-content-relationship}
  */
 export interface CustomTypeModelLinkToMediaField {
-	type: CustomTypeModelFieldType.Link;
+	type: typeof CustomTypeModelFieldType.Link;
 	config: {
 		label: string;
 		placeholder?: string;
-		select: CustomTypeModelLinkSelectType.Media;
+		select: typeof CustomTypeModelLinkSelectType.Media;
 	};
 }
 
@@ -306,7 +306,7 @@ export interface CustomTypeModelLinkToMediaField {
  * More details: {@link https://prismic.io/docs/core-concepts/number}
  */
 export interface CustomTypeModelNumberField {
-	type: CustomTypeModelFieldType.Number;
+	type: typeof CustomTypeModelFieldType.Number;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -325,7 +325,7 @@ export interface CustomTypeModelSelectField<
 	Option extends string = string,
 	DefaultValue extends Option = Option,
 > {
-	type: CustomTypeModelFieldType.Select;
+	type: typeof CustomTypeModelFieldType.Select;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -349,7 +349,7 @@ export type CustomTypeModelRichTextField =
  * More details: {@link https://prismic.io/docs/core-concepts/rich-text-title}
  */
 export interface CustomTypeModelRichTextMultiField {
-	type: CustomTypeModelFieldType.StructuredText;
+	type: typeof CustomTypeModelFieldType.StructuredText;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -364,7 +364,7 @@ export interface CustomTypeModelRichTextMultiField {
  * More details: {@link https://prismic.io/docs/core-concepts/rich-text-title}
  */
 export interface CustomTypeModelRichTextSingleField {
-	type: CustomTypeModelFieldType.StructuredText;
+	type: typeof CustomTypeModelFieldType.StructuredText;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -386,7 +386,7 @@ export type CustomTypeModelTitleField = CustomTypeModelRichTextSingleField;
  * More details: {@link https://prismic.io/docs/core-concepts/key-text}
  */
 export interface CustomTypeModelKeyTextField {
-	type: CustomTypeModelFieldType.Text;
+	type: typeof CustomTypeModelFieldType.Text;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -399,7 +399,7 @@ export interface CustomTypeModelKeyTextField {
  * More details: {@link https://prismic.io/docs/core-concepts/timestamp}
  */
 export interface CustomTypeModelTimestampField {
-	type: CustomTypeModelFieldType.Timestamp;
+	type: typeof CustomTypeModelFieldType.Timestamp;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -412,7 +412,7 @@ export interface CustomTypeModelTimestampField {
  * More details: {@link https://prismic.io/docs/core-concepts/uid}
  */
 export interface CustomTypeModelUIDField {
-	type: CustomTypeModelFieldType.UID;
+	type: typeof CustomTypeModelFieldType.UID;
 	config: {
 		label: string;
 		placeholder?: string;
@@ -430,7 +430,7 @@ export interface CustomTypeModelSliceZoneField<
 		CustomTypeModelSlice | CustomTypeModelSharedSlice
 	> = Record<string, CustomTypeModelSlice | CustomTypeModelSharedSlice>,
 > {
-	type: CustomTypeModelFieldType.Slices;
+	type: typeof CustomTypeModelFieldType.Slices;
 	fieldset: "Slice zone";
 	config: {
 		labels: Record<string, readonly CustomTypeModelSliceLabel[]>;
@@ -453,20 +453,20 @@ export interface CustomTypeModelSliceLabel {
  *
  * More details: {@link https://prismic.io/docs/core-concepts/slices}
  */
-export enum CustomTypeModelSliceDisplay {
-	List = "list",
-	Grid = "grid",
-}
+export const CustomTypeModelSliceDisplay = {
+	List: "list",
+	Grid: "grid",
+} as const;
 
 /**
  * Type identifier for a Slice.
  *
  * More details: {@link https://prismic.io/docs/core-concepts/slices}
  */
-export enum CustomTypeModelSliceType {
-	Slice = "Slice",
-	SharedSlice = "SharedSlice",
-}
+export const CustomTypeModelSliceType = {
+	Slice: "Slice",
+	SharedSlice: "SharedSlice",
+} as const;
 
 /**
  * A Slice for a Custom Type.
@@ -486,11 +486,11 @@ export interface CustomTypeModelSlice<
 		CustomTypeModelFieldForGroup
 	>,
 > {
-	type: CustomTypeModelSliceType.Slice;
+	type: typeof CustomTypeModelSliceType.Slice;
 	fieldset: string;
 	description: string;
 	icon: string;
-	display: CustomTypeModelSliceDisplay;
+	display: typeof CustomTypeModelSliceDisplay[keyof typeof CustomTypeModelSliceDisplay];
 	"non-repeat": NonRepeatFields;
 	repeat: RepeatFields;
 }
@@ -504,7 +504,7 @@ export interface CustomTypeModelSlice<
  * - {@link https://prismic.io/docs/core-concepts/reusing-slices}
  */
 export interface CustomTypeModelSharedSlice {
-	type: CustomTypeModelSliceType.SharedSlice;
+	type: typeof CustomTypeModelSliceType.SharedSlice;
 }
 
 /**
@@ -521,7 +521,7 @@ export interface SharedSliceModel<
 	ID extends string = string,
 	Variation extends SharedSliceModelVariation = SharedSliceModelVariation,
 > {
-	type: CustomTypeModelSliceType.SharedSlice;
+	type: typeof CustomTypeModelSliceType.SharedSlice;
 	id: ID;
 	name: string;
 	description: string;

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -353,19 +353,19 @@ export type ImageField<
 /**
  * Link Types
  */
-export enum LinkType {
-	Any = "Any",
-	Document = "Document",
-	Media = "Media",
-	Web = "Web",
-}
+export const LinkType = {
+	Any: "Any",
+	Document: "Document",
+	Media: "Media",
+	Web: "Web",
+} as const;
 
 /**
  * For link fields that haven't been filled
  *
  * @typeParam Type - The type of link.
  */
-export type EmptyLinkField<Type extends LinkType = LinkType.Any> = {
+export type EmptyLinkField<Type extends typeof LinkType[keyof typeof LinkType] = typeof LinkType.Any> = {
 	link_type: Type | string;
 };
 
@@ -380,7 +380,7 @@ export interface FilledLinkToDocumentField<
 		AnyRegularField | GroupField | SliceZone
 	> = never,
 > {
-	link_type: LinkType.Document;
+	link_type: typeof LinkType.Document;
 	id: string;
 	uid?: string;
 	type: TypeEnum;
@@ -396,7 +396,7 @@ export interface FilledLinkToDocumentField<
  * Link that points to external website
  */
 export interface FilledLinkToWebField {
-	link_type: LinkType.Web;
+	link_type: typeof LinkType.Web;
 	url: string;
 	target?: string;
 }
@@ -405,7 +405,7 @@ export interface FilledLinkToWebField {
  * Link that points to media
  */
 export interface FilledLinkToMediaField {
-	link_type: LinkType.Media;
+	link_type: typeof LinkType.Media;
 	name: string;
 	kind: string;
 	url: string;
@@ -432,7 +432,7 @@ export type RelationField<
 	> = never,
 	State extends FieldState = FieldState,
 > = State extends "empty"
-	? EmptyLinkField<LinkType.Document>
+	? EmptyLinkField<typeof LinkType.Document>
 	: FilledLinkToDocumentField<TypeEnum, LangEnum, DataInterface>;
 
 /**
@@ -453,7 +453,7 @@ export type LinkField<
 	> = never,
 	State extends FieldState = FieldState,
 > = State extends "empty"
-	? EmptyLinkField<LinkType.Any>
+	? EmptyLinkField<typeof LinkType.Any>
 	:
 			| RelationField<TypeEnum, LangEnum, DataInterface, State>
 			| FilledLinkToWebField
@@ -466,7 +466,7 @@ export type LinkField<
  */
 export type LinkToMediaField<State extends FieldState = FieldState> =
 	State extends "empty"
-		? EmptyLinkField<LinkType.Media>
+		? EmptyLinkField<typeof LinkType.Media>
 		: FilledLinkToMediaField;
 
 // Simple Fields
@@ -539,10 +539,10 @@ export type BooleanField = boolean;
 /**
  * Embed Type - Link or RichText Field
  */
-export enum EmbedType {
-	Link = "link",
-	Rich = "rich",
-}
+export const EmbedType = {
+	Link: "link",
+	Rich: "rich",
+} as const;
 
 /**
  * A common set of oEmbed data supported by most providers.
@@ -584,7 +584,7 @@ export type EmbedField<
 	? EmptyObjectField
 	: {
 			embed_url: string;
-			type: EmbedType;
+			type: typeof EmbedType[keyof typeof EmbedType];
 	  } & Data;
 
 /**

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -365,7 +365,9 @@ export const LinkType = {
  *
  * @typeParam Type - The type of link.
  */
-export type EmptyLinkField<Type extends typeof LinkType[keyof typeof LinkType] = typeof LinkType.Any> = {
+export type EmptyLinkField<
+	Type extends typeof LinkType[keyof typeof LinkType] = typeof LinkType.Any,
+> = {
 	link_type: Type | string;
 };
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -10,27 +10,27 @@ export type FieldState = "empty" | "filled";
  *
  * @see More details: {@link https://prismic.io/docs/core-concepts/rich-text-title}
  */
-export enum RichTextNodeType {
-	heading1 = "heading1",
-	heading2 = "heading2",
-	heading3 = "heading3",
-	heading4 = "heading4",
-	heading5 = "heading5",
-	heading6 = "heading6",
-	paragraph = "paragraph",
-	preformatted = "preformatted",
-	strong = "strong",
-	em = "em",
-	listItem = "list-item",
-	oListItem = "o-list-item",
-	list = "group-list-item",
-	oList = "group-o-list-item",
-	image = "image",
-	embed = "embed",
-	hyperlink = "hyperlink",
-	label = "label",
-	span = "span",
-}
+export const RichTextNodeType = {
+	heading1: "heading1",
+	heading2: "heading2",
+	heading3: "heading3",
+	heading4: "heading4",
+	heading5: "heading5",
+	heading6: "heading6",
+	paragraph: "paragraph",
+	preformatted: "preformatted",
+	strong: "strong",
+	em: "em",
+	listItem: "list-item",
+	oListItem: "o-list-item",
+	list: "group-list-item",
+	oList: "group-o-list-item",
+	image: "image",
+	embed: "embed",
+	hyperlink: "hyperlink",
+	label: "label",
+	span: "span",
+} as const;
 
 // Text nodes
 
@@ -46,70 +46,70 @@ export interface RTTextNodeBase {
  * Rich Text `heading1` node
  */
 export interface RTHeading1Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading1;
+	type: typeof RichTextNodeType.heading1;
 }
 
 /**
  * Rich Text `heading2` node
  */
 export interface RTHeading2Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading2;
+	type: typeof RichTextNodeType.heading2;
 }
 
 /**
  * Rich Text `heading3` node
  */
 export interface RTHeading3Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading3;
+	type: typeof RichTextNodeType.heading3;
 }
 
 /**
  * Rich Text `heading4` node
  */
 export interface RTHeading4Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading4;
+	type: typeof RichTextNodeType.heading4;
 }
 
 /**
  * Rich Text `heading5` node
  */
 export interface RTHeading5Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading5;
+	type: typeof RichTextNodeType.heading5;
 }
 
 /**
  * Rich Text `heading6` node
  */
 export interface RTHeading6Node extends RTTextNodeBase {
-	type: RichTextNodeType.heading6;
+	type: typeof RichTextNodeType.heading6;
 }
 
 /**
  * Rich Text `paragraph` node
  */
 export interface RTParagraphNode extends RTTextNodeBase {
-	type: RichTextNodeType.paragraph;
+	type: typeof RichTextNodeType.paragraph;
 }
 
 /**
  * Rich Text `preformatted` node
  */
 export interface RTPreformattedNode extends RTTextNodeBase {
-	type: RichTextNodeType.preformatted;
+	type: typeof RichTextNodeType.preformatted;
 }
 
 /**
  * Rich Text `list-item` node
  */
 export interface RTListItemNode extends RTTextNodeBase {
-	type: RichTextNodeType.listItem;
+	type: typeof RichTextNodeType.listItem;
 }
 
 /**
  * Rich Text `o-list-item` node for ordered lists
  */
 export interface RTOListItemNode extends RTTextNodeBase {
-	type: RichTextNodeType.oListItem;
+	type: typeof RichTextNodeType.oListItem;
 }
 
 // Span nodes
@@ -125,21 +125,21 @@ export interface RTSpanNodeBase {
  * Rich Text `strong` node
  */
 export interface RTStrongNode extends RTSpanNodeBase {
-	type: RichTextNodeType.strong;
+	type: typeof RichTextNodeType.strong;
 }
 
 /**
  * Rich Text `embed` node
  */
 export interface RTEmNode extends RTSpanNodeBase {
-	type: RichTextNodeType.em;
+	type: typeof RichTextNodeType.em;
 }
 
 /**
  * Rich Text `label` node
  */
 export interface RTLabelNode extends RTSpanNodeBase {
-	type: RichTextNodeType.label;
+	type: typeof RichTextNodeType.label;
 	data: {
 		label: string;
 	};
@@ -152,7 +152,7 @@ export interface RTLabelNode extends RTSpanNodeBase {
  * links and media fields
  */
 export type RTImageNode = {
-	type: RichTextNodeType.image;
+	type: typeof RichTextNodeType.image;
 	url: string;
 	alt: string | null;
 	copyright: string | null;
@@ -170,7 +170,7 @@ export type RTImageNode = {
  * Rich Text `embed` node
  */
 export type RTEmbedNode = {
-	type: RichTextNodeType.embed;
+	type: typeof RichTextNodeType.embed;
 	oembed: EmbedField;
 };
 
@@ -182,7 +182,7 @@ export type RTEmbedNode = {
  * @see More details: {@link https://prismic.io/docs/core-concepts/edit-rich-text#add-links}
  */
 export interface RTLinkNode extends RTSpanNodeBase {
-	type: RichTextNodeType.hyperlink;
+	type: typeof RichTextNodeType.hyperlink;
 	data:
 		| FilledLinkToDocumentField
 		| FilledLinkToWebField
@@ -195,7 +195,7 @@ export interface RTLinkNode extends RTSpanNodeBase {
  * Rich Text `list` node
  */
 export interface RTListNode {
-	type: RichTextNodeType.list;
+	type: typeof RichTextNodeType.list;
 	items: RTListItemNode[];
 }
 
@@ -203,7 +203,7 @@ export interface RTListNode {
  * Rich Text o-lost node
  */
 export interface RTOListNode {
-	type: RichTextNodeType.oList;
+	type: typeof RichTextNodeType.oList;
 	items: RTOListItemNode[];
 }
 
@@ -212,7 +212,7 @@ export interface RTOListNode {
  * Rich Text `span` node
  */
 export interface RTSpanNode extends RTTextNodeBase {
-	type: RichTextNodeType.span;
+	type: typeof RichTextNodeType.span;
 }
 
 // Helpers

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -8,7 +8,6 @@ export enum LinkType {
 /**
  * Represents a link field without a value.
  */
-
 export type EmptyLinkField = null;
 
 /**

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -1,9 +1,9 @@
-export enum LinkType {
-	Document = "Link.document",
-	File = "Link.file",
-	Image = "Link.image",
-	Web = "Link.web",
-}
+export const LinkType = {
+	Document: "Link.document",
+	File: "Link.file",
+	Image: "Link.image",
+	Web: "Link.web",
+} as const;
 
 /**
  * Represents a link field without a value.
@@ -14,14 +14,14 @@ export type EmptyLinkField = null;
  * Link that point to Documents
  */
 export interface FilledMinimalLinkToDocumentField {
-	_linkType: LinkType.Document | string;
+	_linkType: typeof LinkType.Document | string;
 }
 
 /**
  * Link that points to external website
  */
 export interface FilledMinimalLinkToWebField {
-	_linkType: LinkType.Web | string;
+	_linkType: typeof LinkType.Web | string;
 	url: string;
 }
 
@@ -29,7 +29,7 @@ export interface FilledMinimalLinkToWebField {
  * Link that points to media (images, PDFs, or any file in the Media Library)
  */
 export interface FilledMinimalLinkToMediaField {
-	_linkType: LinkType.File | LinkType.Image | string;
+	_linkType: typeof LinkType.File | typeof LinkType.Image | string;
 	url: string;
 }
 

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -27,9 +27,7 @@ const ForeignEmbedType = {
 	Link: "link",
 	Breaking: "breaking",
 } as const;
-expectType<typeof prismicT.EmbedType.Link>(
-	ForeignEmbedType.Link,
-);
+expectType<typeof prismicT.EmbedType.Link>(ForeignEmbedType.Link);
 expectType<typeof prismicT.EmbedType.Link>(
 	// @ts-expect-error - `EmbedType` should still fail with breaking changes
 	ForeignEmbedType.Breaking,

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -19,6 +19,23 @@ import * as prismicT from "../src";
 };
 
 /**
+ * `EmbedType` keeps compatibility with other versions.
+ *
+ * @see Related issue {@link https://github.com/prismicio/prismic-types/issues/16}
+ */
+const ForeignEmbedType = {
+	Link: "link",
+	Breaking: "breaking",
+} as const;
+expectType<typeof prismicT.EmbedType.Link>(
+	ForeignEmbedType.Link,
+);
+expectType<typeof prismicT.EmbedType.Link>(
+	// @ts-expect-error - `EmbedType` should still fail with breaking changes
+	ForeignEmbedType.Breaking,
+);
+
+/**
  * Filled state.
  */
 expectType<prismicT.EmbedField>({

--- a/test/fields-link.types.ts
+++ b/test/fields-link.types.ts
@@ -19,6 +19,23 @@ import * as prismicT from "../src";
 };
 
 /**
+ * `LinkType` keeps compatibility with other versions.
+ *
+ * @see Related issue {@link https://github.com/prismicio/prismic-types/issues/16}
+ */
+const ForeignLinkType = {
+	Document: "Document",
+	Breaking: "Breaking",
+} as const;
+expectType<typeof prismicT.LinkType.Document>(
+	ForeignLinkType.Document,
+);
+expectType<typeof prismicT.LinkType.Document>(
+	// @ts-expect-error - `LinkType` should still fail with breaking changes
+	ForeignLinkType.Breaking,
+);
+
+/**
  * Filled state.
  */
 // Web link

--- a/test/fields-link.types.ts
+++ b/test/fields-link.types.ts
@@ -27,9 +27,7 @@ const ForeignLinkType = {
 	Document: "Document",
 	Breaking: "Breaking",
 } as const;
-expectType<typeof prismicT.LinkType.Document>(
-	ForeignLinkType.Document,
-);
+expectType<typeof prismicT.LinkType.Document>(ForeignLinkType.Document);
 expectType<typeof prismicT.LinkType.Document>(
 	// @ts-expect-error - `LinkType` should still fail with breaking changes
 	ForeignLinkType.Breaking,

--- a/test/fields-richText.types.ts
+++ b/test/fields-richText.types.ts
@@ -28,6 +28,23 @@ import * as prismicT from "../src";
 };
 
 /**
+ * `RichTextNodeType` keeps compatibility with other versions.
+ *
+ * @see Related issue {@link https://github.com/prismicio/prismic-types/issues/16}
+ */
+const ForeignRichTextNodeType = {
+	heading1: "heading1",
+	breaking: "breaking",
+} as const;
+expectType<typeof prismicT.RichTextNodeType.heading1>(
+	ForeignRichTextNodeType.heading1,
+);
+expectType<typeof prismicT.RichTextNodeType.heading1>(
+	// @ts-expect-error - `RichTextNodeType` should still fail with breaking changes
+	ForeignRichTextNodeType.breaking,
+);
+
+/**
  * Filled state.
  */
 expectType<prismicT.RichTextField>([

--- a/test/fields.types.ts
+++ b/test/fields.types.ts
@@ -24,7 +24,7 @@ import * as prismicT from "../src";
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.BooleanField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.ColorField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.DateField>>(true);
-expectType<TypeOf<prismicT.AnyRegularField, prismicT.EmbedType>>(true);
+expectType<TypeOf<prismicT.AnyRegularField, prismicT.EmbedField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.GeoPointField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.ImageField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.IntegrationFields>>(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Changed the `enum` to a looser `{} as const` object for `RichTextNodeType`. This should prevent compatibility issues when relying on different versions of `@prismicio/types`.

@angeloashmore, should we proceed the same way with `LinkType`/`EmbedType`? Not sure those were impacted the same way 🤔

Will do the rolling out to kits using `RichTextNodeType` once merged 👌
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #16

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐎