### PR TITLE
feat: support unknown `EmbedField` properties by default

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -557,6 +557,7 @@ export type CommonEmbedData = {
 	url?: string;
 	version?: string;
 	title?: string | null;
+	description?: string | null;
 
 	html?: string | null;
 
@@ -572,6 +573,8 @@ export type CommonEmbedData = {
 	thumbnail_url?: string | null;
 	thumbnail_width?: number | null;
 	thumbnail_height?: number | null;
+
+	[key: string]: unknown | null;
 };
 
 /**

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -70,6 +70,7 @@ expectType<prismicT.EmbedField>({
 	url: "string",
 	version: "string",
 	title: "string",
+	description: "string",
 	html: "string",
 	width: 0,
 	height: 0,
@@ -80,6 +81,15 @@ expectType<prismicT.EmbedField>({
 	thumbnail_url: "string",
 	thumbnail_width: 0,
 	thumbnail_height: 0,
+});
+
+/**
+ * Supports unknown keys by default.
+ */
+expectType<prismicT.EmbedField>({
+	embed_url: "url",
+	type: prismicT.EmbedType.Link,
+	unknown_key: "string",
 });
 
 /**


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for unknown properties by default to `EmbedField`. It does this by adding a general `[key: string]: unknown | null` property to `CommonEmbedData`.

If a `Data` generic type is given, it overrides this new functionality.

This PR also adds a known common `description` property to `CommonEmbedData`. See: https://github.com/prismicio/prismic-client/issues/216

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦁
