### PR TITLE
refactor(fields): use oembed specs for embed field

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
 	"plugins": ["prettier-plugin-jsdoc"],
+	"jsdocCapitalizeDescription": false,
 	"jsdocSeparateReturnsFromParam": true,
 	"jsdocSingleLineComment": false,
 	"tsdoc": true,

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -559,7 +559,7 @@ type OEmbedBase<TType extends typeof OEmbedType[keyof typeof OEmbedType]> = {
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
-export type OEmbedPhoto = OEmbedBase<typeof OEmbedType.Photo> & {
+export type PhotoOEmbed = OEmbedBase<typeof OEmbedType.Photo> & {
 	/**
 	 * OEmbed source URL of the image.
 	 */
@@ -579,7 +579,7 @@ export type OEmbedPhoto = OEmbedBase<typeof OEmbedType.Photo> & {
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
-export type OEmbedVideo = OEmbedBase<typeof OEmbedType.Video> & {
+export type VideoOEmbed = OEmbedBase<typeof OEmbedType.Video> & {
 	/**
 	 * OEmbed HTML required to embed a video player.
 	 */
@@ -599,14 +599,14 @@ export type OEmbedVideo = OEmbedBase<typeof OEmbedType.Video> & {
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
-export type OEmbedLink = OEmbedBase<typeof OEmbedType.Link>;
+export type LinkOEmbed = OEmbedBase<typeof OEmbedType.Link>;
 
 /**
  * OEmbed rich type.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
-export type OEmbedRich = OEmbedBase<typeof OEmbedType.Rich> & {
+export type RichOEmbed = OEmbedBase<typeof OEmbedType.Rich> & {
 	/**
 	 * OEmbed HTML required to display the resource.
 	 */
@@ -626,24 +626,24 @@ export type OEmbedRich = OEmbedBase<typeof OEmbedType.Rich> & {
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
-export type AnyOEmbed = OEmbedPhoto | OEmbedVideo | OEmbedLink | OEmbedRich;
+export type AnyOEmbed = PhotoOEmbed | VideoOEmbed | LinkOEmbed | RichOEmbed;
 
 /**
  * An Embed field.
  *
- * @typeParam ExtraData - Known extra data provided by the URL's oEmbed provider.
+ * @typeParam Data - Data provided by the URL's oEmbed provider.
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/core-concepts/embed}
  */
 export type EmbedField<
-	ExtraData extends Record<string, unknown> = Record<string, unknown>,
+	Data extends AnyOEmbed = AnyOEmbed,
 	State extends FieldState = FieldState,
 > = State extends "empty"
 	? EmptyObjectField
-	: AnyOEmbed & {
+	: Data & {
 			embed_url: string;
 			html: string | null;
-	  } & ExtraData;
+	  };
 
 // Simple Fields
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -477,7 +477,7 @@ export type LinkToMediaField<State extends FieldState = FieldState> =
 // Embed
 
 /**
- * OEmbed 1.0 possible types.
+ * oEmbed 1.0 possible types.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
@@ -489,60 +489,74 @@ export const OEmbedType = {
 } as const;
 
 /**
- * OEmbed response base fields.
+ * oEmbed response base fields. Those are every mandatory fields an oEmbed
+ * response must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
 type OEmbedBase<TType extends typeof OEmbedType[keyof typeof OEmbedType]> = {
 	/**
-	 * OEmbed resource type.
+	 * oEmbed resource type.
 	 */
 	type: TType;
+
 	/**
-	 * OEmbed version number, this must be "1.0".
+	 * oEmbed version number, this must be "1.0".
 	 */
 	version: string;
+};
+
+/**
+ * oEmbed response extra fields. Those are every non-mandatory and unknown
+ * fields an oEmbed response can feature.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type OEmbedExtra = {
+	/**
+	 * oEmbed text title, describing the resource.
+	 */
+	title?: string | null;
 
 	/**
-	 * OEmbed text title, describing the resource.
+	 * oEmbed resource author/owner name.
 	 */
-	title: string | null;
+	author_name?: string | null;
 
 	/**
-	 * OEmbed resource author/owner name.
+	 * oEmbed resource author/owner URL.
 	 */
-	author_name: string | null;
-	/**
-	 * OEmbed resource author/owner URL.
-	 */
-	author_url: string | null;
+	author_url?: string | null;
 
 	/**
-	 * OEmbed resource provider name.
+	 * oEmbed resource provider name.
 	 */
-	provider_name: string | null;
-	/**
-	 * OEmbed resource provider URL.
-	 */
-	provider_url: string | null;
+	provider_name?: string | null;
 
 	/**
-	 * OEmbed suggested cache lifetime for the resource, in seconds.
+	 * oEmbed resource provider URL.
 	 */
-	cache_age: number | null;
+	provider_url?: string | null;
 
 	/**
-	 * OEmbed resource thumbnail URL.
+	 * oEmbed suggested cache lifetime for the resource, in seconds.
 	 */
-	thumbnail_url: string | null;
+	cache_age?: number | null;
+
 	/**
-	 * OEmbed resource thumbnail width.
+	 * oEmbed resource thumbnail URL.
 	 */
-	thumbnail_width: number | null;
+	thumbnail_url?: string | null;
+
 	/**
-	 * OEmbed resource thumbnail height.
+	 * oEmbed resource thumbnail width.
 	 */
-	thumbnail_height: number | null;
+	thumbnail_width?: number | null;
+
+	/**
+	 * oEmbed resource thumbnail height.
+	 */
+	thumbnail_height?: number | null;
 
 	/**
 	 * Providers may optionally include any parameters not specified in this
@@ -551,78 +565,89 @@ type OEmbedBase<TType extends typeof OEmbedType[keyof typeof OEmbedType]> = {
 	 *
 	 * @see oEmbed specification: {@link https://oembed.com}
 	 */
-	[key: string]: unknown;
+	[key: string]: unknown | null;
 };
 
 /**
- * OEmbed photo type.
+ * oEmbed photo type. Those are every mandatory fields an oEmbed photo response
+ * must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
 export type PhotoOEmbed = OEmbedBase<typeof OEmbedType.Photo> & {
 	/**
-	 * OEmbed source URL of the image.
+	 * oEmbed source URL of the image.
 	 */
 	url: string;
+
 	/**
-	 * OEmbed width in pixels of the image.
+	 * oEmbed width in pixels of the image.
 	 */
 	width: number;
+
 	/**
-	 * OEmbed height in pixels of the image.
+	 * oEmbed height in pixels of the image.
 	 */
 	height: number;
 };
 
 /**
- * OEmbed video type.
+ * oEmbed video type. Those are every mandatory fields an oEmbed video response
+ * must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
 export type VideoOEmbed = OEmbedBase<typeof OEmbedType.Video> & {
 	/**
-	 * OEmbed HTML required to embed a video player.
+	 * oEmbed HTML required to embed a video player.
 	 */
 	html: string;
+
 	/**
-	 * OEmbed width in pixels required to display the HTML.
+	 * oEmbed width in pixels required to display the HTML.
 	 */
 	width: number;
+
 	/**
-	 * OEmbed height in pixels required to display the HTML.
+	 * oEmbed height in pixels required to display the HTML.
 	 */
 	height: number;
 };
 
 /**
- * OEmbed link type.
+ * oEmbed link type. Those are every mandatory fields an oEmbed link response
+ * must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
 export type LinkOEmbed = OEmbedBase<typeof OEmbedType.Link>;
 
 /**
- * OEmbed rich type.
+ * oEmbed rich type. Those are every mandatory fields an oEmbed rich response
+ * must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
 export type RichOEmbed = OEmbedBase<typeof OEmbedType.Rich> & {
 	/**
-	 * OEmbed HTML required to display the resource.
+	 * oEmbed HTML required to display the resource.
 	 */
 	html: string;
+
 	/**
-	 * OEmbed width in pixels required to display the HTML.
+	 * oEmbed width in pixels required to display the HTML.
 	 */
 	width: number;
+
 	/**
-	 * OEmbed height in pixels required to display the HTML.
+	 * oEmbed height in pixels required to display the HTML.
 	 */
 	height: number;
 };
 
 /**
- * Any of the possible types of oEmbed response.
+ * Any of the possible types of oEmbed response. Those contains only mandatory
+ * fields their respective oEmbed response type must feature.
  *
  * @see oEmbed specification: {@link https://oembed.com}
  */
@@ -636,7 +661,7 @@ export type AnyOEmbed = PhotoOEmbed | VideoOEmbed | LinkOEmbed | RichOEmbed;
  * @see More details: {@link https://prismic.io/docs/core-concepts/embed}
  */
 export type EmbedField<
-	Data extends AnyOEmbed = AnyOEmbed,
+	Data extends AnyOEmbed = AnyOEmbed & OEmbedExtra,
 	State extends FieldState = FieldState,
 > = State extends "empty"
 	? EmptyObjectField

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -352,6 +352,7 @@ export type ImageField<
 	: ImageFieldImage<State>;
 
 // Links
+
 /**
  * Link Types
  */
@@ -473,6 +474,177 @@ export type LinkToMediaField<State extends FieldState = FieldState> =
 		? EmptyLinkField<typeof LinkType.Media>
 		: FilledLinkToMediaField;
 
+// Embed
+
+/**
+ * OEmbed 1.0 possible types.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export const OEmbedType = {
+	Photo: "photo",
+	Video: "video",
+	Link: "link",
+	Rich: "rich",
+} as const;
+
+/**
+ * OEmbed response base fields.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+type OEmbedBase<TType extends typeof OEmbedType[keyof typeof OEmbedType]> = {
+	/**
+	 * OEmbed resource type.
+	 */
+	type: TType;
+	/**
+	 * OEmbed version number, this must be "1.0".
+	 */
+	version: string;
+
+	/**
+	 * OEmbed text title, describing the resource.
+	 */
+	title: string | null;
+
+	/**
+	 * OEmbed resource author/owner name.
+	 */
+	author_name: string | null;
+	/**
+	 * OEmbed resource author/owner URL.
+	 */
+	author_url: string | null;
+
+	/**
+	 * OEmbed resource provider name.
+	 */
+	provider_name: string | null;
+	/**
+	 * OEmbed resource provider URL.
+	 */
+	provider_url: string | null;
+
+	/**
+	 * OEmbed suggested cache lifetime for the resource, in seconds.
+	 */
+	cache_age: number | null;
+
+	/**
+	 * OEmbed resource thumbnail URL.
+	 */
+	thumbnail_url: string | null;
+	/**
+	 * OEmbed resource thumbnail width.
+	 */
+	thumbnail_width: number | null;
+	/**
+	 * OEmbed resource thumbnail height.
+	 */
+	thumbnail_height: number | null;
+
+	/**
+	 * Providers may optionally include any parameters not specified in this
+	 * document (so long as they use the same key-value format) and consumers may
+	 * choose to ignore these. Consumers must ignore parameters they do not understand.
+	 *
+	 * @see oEmbed specification: {@link https://oembed.com}
+	 */
+	[key: string]: unknown;
+};
+
+/**
+ * OEmbed photo type.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type OEmbedPhoto = OEmbedBase<typeof OEmbedType.Photo> & {
+	/**
+	 * OEmbed source URL of the image.
+	 */
+	url: string;
+	/**
+	 * OEmbed width in pixels of the image.
+	 */
+	width: number;
+	/**
+	 * OEmbed height in pixels of the image.
+	 */
+	height: number;
+};
+
+/**
+ * OEmbed video type.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type OEmbedVideo = OEmbedBase<typeof OEmbedType.Video> & {
+	/**
+	 * OEmbed HTML required to embed a video player.
+	 */
+	html: string;
+	/**
+	 * OEmbed width in pixels required to display the HTML.
+	 */
+	width: number;
+	/**
+	 * OEmbed height in pixels required to display the HTML.
+	 */
+	height: number;
+};
+
+/**
+ * OEmbed link type.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type OEmbedLink = OEmbedBase<typeof OEmbedType.Link>;
+
+/**
+ * OEmbed rich type.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type OEmbedRich = OEmbedBase<typeof OEmbedType.Rich> & {
+	/**
+	 * OEmbed HTML required to display the resource.
+	 */
+	html: string;
+	/**
+	 * OEmbed width in pixels required to display the HTML.
+	 */
+	width: number;
+	/**
+	 * OEmbed height in pixels required to display the HTML.
+	 */
+	height: number;
+};
+
+/**
+ * Any of the possible types of oEmbed response.
+ *
+ * @see oEmbed specification: {@link https://oembed.com}
+ */
+export type AnyOEmbed = OEmbedPhoto | OEmbedVideo | OEmbedLink | OEmbedRich;
+
+/**
+ * An Embed field.
+ *
+ * @typeParam ExtraData - Known extra data provided by the URL's oEmbed provider.
+ * @typeParam State - State of the field which determines its shape.
+ * @see More details: {@link https://prismic.io/docs/core-concepts/embed}
+ */
+export type EmbedField<
+	ExtraData extends Record<string, unknown> = Record<string, unknown>,
+	State extends FieldState = FieldState,
+> = State extends "empty"
+	? EmptyObjectField
+	: AnyOEmbed & {
+			embed_url: string;
+			html: string | null;
+	  } & ExtraData;
+
 // Simple Fields
 
 /**
@@ -539,60 +711,6 @@ export type SelectField<
  * @see More details: {@link https://prismic.io/docs/core-concepts/boolean}
  */
 export type BooleanField = boolean;
-
-/**
- * Embed Type - Link or RichText Field
- */
-export const EmbedType = {
-	Link: "link",
-	Rich: "rich",
-} as const;
-
-/**
- * A common set of oEmbed data supported by most providers.
- *
- * @see More details: {@link https://prismic.io/docs/core-concepts/embed}
- */
-export type CommonEmbedData = {
-	url?: string;
-	version?: string;
-	title?: string | null;
-	description?: string | null;
-
-	html?: string | null;
-
-	width?: number | null;
-	height?: number | null;
-
-	author_name?: string | null;
-	author_url?: string | null;
-
-	provider_name?: string;
-	cache_age?: number | null;
-
-	thumbnail_url?: string | null;
-	thumbnail_width?: number | null;
-	thumbnail_height?: number | null;
-
-	[key: string]: unknown | null;
-};
-
-/**
- * An Embed field.
- *
- * @typeParam Data - Data provided by the URL's oEmbed provider.
- * @typeParam State - State of the field which determines its shape.
- * @see More details: {@link https://prismic.io/docs/core-concepts/embed}
- */
-export type EmbedField<
-	Data extends Record<string, unknown> = CommonEmbedData,
-	State extends FieldState = FieldState,
-> = State extends "empty"
-	? EmptyObjectField
-	: {
-			embed_url: string;
-			type: typeof EmbedType[keyof typeof EmbedType];
-	  } & Data;
 
 /**
  * A Geopoint field.

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
 	LinkField,
 	LinkToMediaField,
 	// Embed
+	OEmbedExtra,
 	PhotoOEmbed,
 	VideoOEmbed,
 	LinkOEmbed,
@@ -95,6 +96,7 @@ export type {
 
 // Deprecations (unused import for @link references)
 import type {
+	OEmbedExtra,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	PhotoOEmbed,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -109,7 +111,7 @@ import type {
  * @deprecated Use {@link PhotoOEmbed}, {@link VideoOEmbed}, {@link LinkOEmbed},
  *   {@link RichOEmbed}, or {@link AnyOEmbed} instead.
  */
-export type CommonEmbedData = AnyOEmbed;
+export type CommonEmbedData = AnyOEmbed & OEmbedExtra;
 
 export {
 	CustomTypeModelFieldType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,10 @@ export type {
 	LinkField,
 	LinkToMediaField,
 	// Embed
-	OEmbedPhoto,
-	OEmbedVideo,
-	OEmbedLink,
-	OEmbedRich,
+	PhotoOEmbed,
+	VideoOEmbed,
+	LinkOEmbed,
+	RichOEmbed,
 	AnyOEmbed,
 	EmbedField,
 	// Simple
@@ -94,12 +94,20 @@ export type {
 } from "./fields";
 
 // Deprecations (unused import for @link references)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { AnyOEmbed, EmbedField } from "./fields";
+import type {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	PhotoOEmbed,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	VideoOEmbed,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	LinkOEmbed,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	RichOEmbed,
+	AnyOEmbed,
+} from "./fields";
 /**
- * @deprecated You don't need to extend this type anymore when creating custom
- *   embed fields, just provide the extra properties you need to the first
- *   generic of {@link EmbedField}.
+ * @deprecated Use {@link PhotoOEmbed}, {@link VideoOEmbed}, {@link LinkOEmbed},
+ *   {@link RichOEmbed}, or {@link AnyOEmbed} instead.
  */
 export type CommonEmbedData = AnyOEmbed;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type {
 	AlternateLanguage,
 } from "./document";
 
-export { RichTextNodeType, LinkType, EmbedType } from "./fields";
+export { RichTextNodeType, LinkType, OEmbedType } from "./fields";
 
 export type {
 	// RichText & Title
@@ -57,6 +57,13 @@ export type {
 	RelationField,
 	LinkField,
 	LinkToMediaField,
+	// Embed
+	OEmbedPhoto,
+	OEmbedVideo,
+	OEmbedLink,
+	OEmbedRich,
+	AnyOEmbed,
+	EmbedField,
 	// Simple
 	DateField,
 	TimestampField,
@@ -65,8 +72,6 @@ export type {
 	KeyTextField,
 	SelectField,
 	BooleanField,
-	EmbedField,
-	CommonEmbedData,
 	GeoPointField,
 	// Complex
 	GroupField,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,13 @@ export type {
 
 export { RichTextNodeType, LinkType, OEmbedType } from "./fields";
 
+// Deprecations
+import { OEmbedType } from "./fields";
+/**
+ * @deprecated Use {@link OEmbedType} instead.
+ */
+export const EmbedType = OEmbedType;
+
 export type {
 	// RichText & Title
 	TitleField,
@@ -85,6 +92,16 @@ export type {
 	// Meta
 	FieldState,
 } from "./fields";
+
+// Deprecations (unused import for @link references)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { AnyOEmbed, EmbedField } from "./fields";
+/**
+ * @deprecated You don't need to extend this type anymore when creating custom
+ *   embed fields, just provide the extra properties you need to the first
+ *   generic of {@link EmbedField}.
+ */
+export type CommonEmbedData = AnyOEmbed;
 
 export {
 	CustomTypeModelFieldType,

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -55,15 +55,6 @@ expectType<prismicT.EmbedField<prismicT.LinkOEmbed, "filled">>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",
-	title: null,
-	author_name: null,
-	author_url: null,
-	provider_name: null,
-	provider_url: null,
-	cache_age: null,
-	thumbnail_url: null,
-	thumbnail_width: null,
-	thumbnail_height: null,
 	html: null,
 });
 expectType<prismicT.EmbedField<prismicT.LinkOEmbed, "empty">>({
@@ -73,24 +64,6 @@ expectType<prismicT.EmbedField<prismicT.LinkOEmbed, "empty">>({
 	type: prismicT.OEmbedType.Link,
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	version: "1.0",
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	title: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	author_name: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	author_url: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	provider_name: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	provider_url: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	cache_age: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	thumbnail_url: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	thumbnail_width: null,
-	// @ts-expect-error - Empty fields cannot contain a filled value.
-	thumbnail_height: null,
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	html: null,
 });
@@ -151,15 +124,6 @@ expectType<prismicT.EmbedField<prismicT.LinkOEmbed & { foo: "bar" }>>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",
-	title: null,
-	author_name: null,
-	author_url: null,
-	provider_name: null,
-	provider_url: null,
-	cache_age: null,
-	thumbnail_url: null,
-	thumbnail_width: null,
-	thumbnail_height: null,
 	html: null,
 	foo: "bar",
 });
@@ -171,15 +135,6 @@ expectType<prismicT.EmbedField<prismicT.LinkOEmbed & { foo: "bar" }>>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",
-	title: null,
-	author_name: null,
-	author_url: null,
-	provider_name: null,
-	provider_url: null,
-	cache_age: null,
-	thumbnail_url: null,
-	thumbnail_width: null,
-	thumbnail_height: null,
 	html: null,
 	// @ts-expect-error - Now expects `foo` to be `"bar"`.
 	foo: "baz",

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -27,8 +27,8 @@ const ForeignEmbedType = {
 	Link: "link",
 	Breaking: "breaking",
 } as const;
-expectType<typeof prismicT.EmbedType.Link>(ForeignEmbedType.Link);
-expectType<typeof prismicT.EmbedType.Link>(
+expectType<typeof prismicT.OEmbedType.Link>(ForeignEmbedType.Link);
+expectType<typeof prismicT.OEmbedType.Link>(
 	// @ts-expect-error - `EmbedType` should still fail with breaking changes
 	ForeignEmbedType.Breaking,
 );
@@ -37,26 +37,70 @@ expectType<typeof prismicT.EmbedType.Link>(
  * Filled state.
  */
 expectType<prismicT.EmbedField>({
-	embed_url: "url",
-	type: prismicT.EmbedType.Link,
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: null,
+	author_name: null,
+	author_url: null,
+	provider_name: null,
+	provider_url: null,
+	cache_age: null,
+	thumbnail_url: null,
+	thumbnail_width: null,
+	thumbnail_height: null,
+	html: null,
 });
-expectType<prismicT.EmbedField<prismicT.CommonEmbedData, "filled">>({
-	embed_url: "url",
-	type: prismicT.EmbedType.Link,
+expectType<prismicT.EmbedField<Record<string, unknown>, "filled">>({
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: null,
+	author_name: null,
+	author_url: null,
+	provider_name: null,
+	provider_url: null,
+	cache_age: null,
+	thumbnail_url: null,
+	thumbnail_width: null,
+	thumbnail_height: null,
+	html: null,
 });
-expectType<prismicT.EmbedField<prismicT.CommonEmbedData, "empty">>({
+expectType<prismicT.EmbedField<Record<string, unknown>, "empty">>({
 	// @ts-expect-error - Empty fields cannot contain a filled value.
-	embed_url: "url",
+	embed_url: "https://example.com",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
-	type: prismicT.EmbedType.Link,
+	type: prismicT.OEmbedType.Link,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	version: "1.0",
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	title: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	author_name: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	author_url: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	provider_name: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	provider_url: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	cache_age: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	thumbnail_url: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	thumbnail_width: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	thumbnail_height: null,
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	html: null,
 });
 
 /**
  * Empty state.
  */
 expectType<prismicT.EmbedField>({});
-expectType<prismicT.EmbedField<prismicT.CommonEmbedData, "empty">>({});
-expectType<prismicT.EmbedField<prismicT.CommonEmbedData, "filled">>(
+expectType<prismicT.EmbedField<Record<string, unknown>, "empty">>({});
+expectType<prismicT.EmbedField<Record<string, unknown>, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	{},
 );
@@ -65,30 +109,38 @@ expectType<prismicT.EmbedField<prismicT.CommonEmbedData, "filled">>(
  * Includes common oEmbed data by default.
  */
 expectType<prismicT.EmbedField>({
-	embed_url: "url",
-	type: prismicT.EmbedType.Link,
-	url: "string",
-	version: "string",
-	title: "string",
-	description: "string",
-	html: "string",
-	width: 0,
-	height: 0,
-	author_name: "string",
-	author_url: "string",
-	provider_name: "string",
-	cache_age: 0,
-	thumbnail_url: "string",
-	thumbnail_width: 0,
-	thumbnail_height: 0,
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: "title",
+	author_name: "author_name",
+	author_url: "author_url",
+	provider_name: "provider_name",
+	provider_url: "provider_url",
+	cache_age: 42,
+	thumbnail_url: "thumbnail_url",
+	thumbnail_width: 666,
+	thumbnail_height: 999,
+	html: "html",
 });
 
 /**
  * Supports unknown keys by default.
  */
 expectType<prismicT.EmbedField>({
-	embed_url: "url",
-	type: prismicT.EmbedType.Link,
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: null,
+	author_name: null,
+	author_url: null,
+	provider_name: null,
+	provider_url: null,
+	cache_age: null,
+	thumbnail_url: null,
+	thumbnail_width: null,
+	thumbnail_height: null,
+	html: null,
 	unknown_key: "string",
 });
 
@@ -96,7 +148,39 @@ expectType<prismicT.EmbedField>({
  * Supports custom oEmbed data.
  */
 expectType<prismicT.EmbedField<{ foo: "bar" }>>({
-	embed_url: "url",
-	type: prismicT.EmbedType.Link,
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: null,
+	author_name: null,
+	author_url: null,
+	provider_name: null,
+	provider_url: null,
+	cache_age: null,
+	thumbnail_url: null,
+	thumbnail_width: null,
+	thumbnail_height: null,
+	html: null,
 	foo: "bar",
+});
+
+/**
+ * Gives priority to custom oEmbed data.
+ */
+expectType<prismicT.EmbedField<{ foo: "bar" }>>({
+	embed_url: "https://example.com",
+	type: prismicT.OEmbedType.Link,
+	version: "1.0",
+	title: null,
+	author_name: null,
+	author_url: null,
+	provider_name: null,
+	provider_url: null,
+	cache_age: null,
+	thumbnail_url: null,
+	thumbnail_width: null,
+	thumbnail_height: null,
+	html: null,
+	// @ts-expect-error - Now expects `foo` to be `"bar"`.
+	foo: "baz",
 });

--- a/test/fields-embed.types.ts
+++ b/test/fields-embed.types.ts
@@ -51,7 +51,7 @@ expectType<prismicT.EmbedField>({
 	thumbnail_height: null,
 	html: null,
 });
-expectType<prismicT.EmbedField<Record<string, unknown>, "filled">>({
+expectType<prismicT.EmbedField<prismicT.LinkOEmbed, "filled">>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",
@@ -66,7 +66,7 @@ expectType<prismicT.EmbedField<Record<string, unknown>, "filled">>({
 	thumbnail_height: null,
 	html: null,
 });
-expectType<prismicT.EmbedField<Record<string, unknown>, "empty">>({
+expectType<prismicT.EmbedField<prismicT.LinkOEmbed, "empty">>({
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	embed_url: "https://example.com",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
@@ -99,8 +99,8 @@ expectType<prismicT.EmbedField<Record<string, unknown>, "empty">>({
  * Empty state.
  */
 expectType<prismicT.EmbedField>({});
-expectType<prismicT.EmbedField<Record<string, unknown>, "empty">>({});
-expectType<prismicT.EmbedField<Record<string, unknown>, "filled">>(
+expectType<prismicT.EmbedField<prismicT.AnyOEmbed, "empty">>({});
+expectType<prismicT.EmbedField<prismicT.AnyOEmbed, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	{},
 );
@@ -147,7 +147,7 @@ expectType<prismicT.EmbedField>({
 /**
  * Supports custom oEmbed data.
  */
-expectType<prismicT.EmbedField<{ foo: "bar" }>>({
+expectType<prismicT.EmbedField<prismicT.LinkOEmbed & { foo: "bar" }>>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",
@@ -167,7 +167,7 @@ expectType<prismicT.EmbedField<{ foo: "bar" }>>({
 /**
  * Gives priority to custom oEmbed data.
  */
-expectType<prismicT.EmbedField<{ foo: "bar" }>>({
+expectType<prismicT.EmbedField<prismicT.LinkOEmbed & { foo: "bar" }>>({
 	embed_url: "https://example.com",
 	type: prismicT.OEmbedType.Link,
 	version: "1.0",

--- a/test/fields-richText.types.ts
+++ b/test/fields-richText.types.ts
@@ -132,8 +132,19 @@ expectType<prismicT.RichTextField>([
 	{
 		type: prismicT.RichTextNodeType.embed,
 		oembed: {
-			type: prismicT.EmbedType.Rich,
-			embed_url: "string",
+			embed_url: "https://example.com",
+			type: prismicT.OEmbedType.Link,
+			version: "1.0",
+			title: null,
+			author_name: null,
+			author_url: null,
+			provider_name: null,
+			provider_url: null,
+			cache_age: null,
+			thumbnail_url: null,
+			thumbnail_width: null,
+			thumbnail_height: null,
+			html: null,
 		},
 	},
 ]);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -36,9 +36,11 @@ test("link type mapping", (t) => {
 });
 
 test("embed type mapping", (t) => {
-	t.deepEqual(prismicT.EmbedType, {
-		Rich: "rich",
+	t.deepEqual(prismicT.OEmbedType, {
+		Photo: "photo",
+		Video: "video",
 		Link: "link",
+		Rich: "rich",
 	});
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) _(maybe)_

## Description

<!--- Describe your changes in detail -->
Since the API follows carefully the oEmbed spec, this PR refactors the embed field definition to follow the specification and allow for better type guarding. See:
- [oEmbed specification](https://oembed.com)
- [API embed field serialization](https://github.com/prismicio/wroom/blob/9ad56ffd0ed084fc5d6b84bd9042b09a7f90b739/app/models/widgets/WidgetData.scala#L799-L817)

Have been deprecated:
- `EmbedType`, replaced by `OEmbedType`
- `CommonEmbedData`, replaced by `PhotoOEmbed`, `VideoOEmbed`, `LinkOEmbed`, `RichOEmbed`, or `AnyOEmbed`

I changed `EmbedField` first generic to extend `AnyOEmbed` (previously `Record<string, unknown>`) to enforce provided type to extend a valid oEmbed response. This is technically a breaking change for TypeScript users that were using that generic, however, as long as they were extending `CommonEmbedData` they won't face any issue. Given the specificity of it we can consider it as a minor one I think, more of a bug fix.

Fixes: https://github.com/prismicio/prismic-client/issues/216 (if this PR lands, you might need to update your comment there for the posterity of that question @angeloashmore)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦩