### PR TITLE
fix: support union with image thumbnails, fixes #27

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -343,6 +343,7 @@ export interface EmptyImageFieldImage {
 export type ImageField<
 	ThumbnailNames extends string | null = never,
 	State extends FieldState = FieldState,
+	// `Omit<>` is used to prevent TypeScript from considering the refactored type as an array, see #29
 > = Omit<
 	ImageFieldImage<State> &
 		Record<

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -341,15 +341,18 @@ export interface EmptyImageFieldImage {
  * @see Image field documentation: {@link https://prismic.io/docs/core-concepts/image}
  */
 export type ImageField<
-	ThumbnailNames extends string | null = null,
+	ThumbnailNames extends string | null = never,
 	State extends FieldState = FieldState,
-> = ThumbnailNames extends string
-	? ImageFieldImage<State> &
-			Record<
-				Exclude<ThumbnailNames, keyof ImageFieldImage>,
-				ImageFieldImage<State>
-			>
-	: ImageFieldImage<State>;
+> = Omit<
+	ImageFieldImage<State> &
+		Record<
+			ThumbnailNames extends string
+				? Exclude<ThumbnailNames, keyof ImageFieldImage>
+				: never,
+			ImageFieldImage
+		>,
+	never
+>;
 
 // Links
 

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -112,6 +112,10 @@ expectType<prismicT.ImageField<"Foo" | "Bar">>({
 		copyright: "copyright",
 	},
 });
+// See: #27
+const withThumbnails = {} as prismicT.ImageField<"Foo" | "Bar">;
+withThumbnails.Foo;
+withThumbnails.Bar;
 
 /**
  * Thumbnails can be disabled with `null` ThumbnailNames.
@@ -129,3 +133,8 @@ expectType<prismicT.ImageField<null>>({
 		copyright: "copyright",
 	},
 });
+const withoutThumbnails = {} as prismicT.ImageField<null>;
+// @ts-expect-error - No thumbnails should be included when set to `null`.
+withoutThumbnails.Foo;
+// @ts-expect-error - No thumbnails should be included when set to `null`.
+withoutThumbnails.Bar;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
Union with image thumbnails were not handled correctly with TypeScript. This PR fixes it by refactoring the type, extending the root image object with thumbnails, and wrapping it with `Omit<>` to prevent TypeScript from considering the refactored type as an array (found by @angeloashmore).

Just created a PR to make sure we're aligned on it before moving forward with this "hacky" method. The goal of `@prismicio/types` being to provide types as close and precise as possible to what Prismic API responses can be.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #27

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
