### PR TITLE
fix: `ImageField` should be a valid `ImageFieldImage` extend, fixes #30

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -343,17 +343,24 @@ export interface EmptyImageFieldImage {
 export type ImageField<
 	ThumbnailNames extends string | null = never,
 	State extends FieldState = FieldState,
-	// `Omit<>` is used to prevent TypeScript from considering the refactored type as an array, see #29
-> = Omit<
-	ImageFieldImage<State> &
-		Record<
-			ThumbnailNames extends string
-				? Exclude<ThumbnailNames, keyof ImageFieldImage>
-				: never,
-			ImageFieldImage<State>
-		>,
-	never
->;
+> = ImageFieldImage<State> &
+	Record<
+		ThumbnailNames extends string
+			? Exclude<ThumbnailNames, keyof ImageFieldImage>
+			: never,
+		ImageFieldImage<State>
+	> &
+	// This is used to prevent TypeScript from considering the refactored type as an array, see #29, #31
+	("length" extends ThumbnailNames
+		? { length: ImageFieldImage<State> }
+		: {
+				/**
+				 * @deprecated This key does not exists in your current Image field. It
+				 *   is used to handle some TypeScript edge-cases.
+				 * @internal
+				 */
+				length?: never;
+		  });
 
 // Links
 

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -1,4 +1,4 @@
-import { expectType, expectNever } from "ts-expect";
+import { expectType, expectNever, TypeOf } from "ts-expect";
 
 import * as prismicT from "../src";
 
@@ -138,3 +138,56 @@ const withoutThumbnails = {} as prismicT.ImageField<null>;
 withoutThumbnails.Foo;
 // @ts-expect-error - No thumbnails should be included when set to `null`.
 withoutThumbnails.Bar;
+
+/**
+ * Thumbnail name can be `"length"` (edge case, see: #31)
+ */
+expectType<prismicT.ImageField>({
+	url: "url",
+	dimensions: { width: 1, height: 1 },
+	alt: "alt",
+	copyright: "copyright",
+	// @ts-expect-error - `"length"` shouldn't be available as a thumbnail name by default
+	length: {
+		url: "url",
+		dimensions: { width: 1, height: 1 },
+		alt: "alt",
+		copyright: "copyright",
+	},
+});
+expectType<prismicT.ImageField<"length">>({
+	url: "url",
+	dimensions: { width: 1, height: 1 },
+	alt: "alt",
+	copyright: "copyright",
+	length: {
+		url: "url",
+		dimensions: { width: 1, height: 1 },
+		alt: "alt",
+		copyright: "copyright",
+	},
+});
+
+/**
+ * ImageFields are valid ImageFieldImage extends.
+ */
+expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField>>(true);
+expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<null>>>(true);
+expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<"Foo">>>(true);
+expectType<
+	TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<"Foo" | "Bar">>
+>(true);
+const _ImageFieldIsValidImageFieldImageExtendDebug: prismicT.ImageFieldImage =
+	{} as prismicT.ImageField;
+
+/**
+ * ImageFieldImages are valid ImageField extends with no thumbnails.
+ */
+expectType<TypeOf<prismicT.ImageField, prismicT.ImageFieldImage>>(true);
+expectType<TypeOf<prismicT.ImageField<null>, prismicT.ImageFieldImage>>(true);
+expectType<TypeOf<prismicT.ImageField<"Foo">, prismicT.ImageFieldImage>>(false);
+expectType<
+	TypeOf<prismicT.ImageField<"Foo" | "Bar">, prismicT.ImageFieldImage>
+>(false);
+const _ImageFieldImageIsValidImageFieldExtendDebug: prismicT.ImageField =
+	{} as prismicT.ImageFieldImage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
Starting to lose my mind with that one... #29 introduced some regression with the Image field type, see #30 for issue details.

<!--- Why is this change required? What problem does it solve? -->
I haven't found a perfect workaround. In this PR I removed the murky `Omit<K, never>` hack from #29 and replaced it with a "smart-ish" `"length"` key exclusion.

The downside of that approach is that `"length"` now appears in IntelliSense despite being marked as _internal_ and _deprecated_ (deprecated isn't really true, but at least it makes it scary to use/obviously not a thing you'd care about).

<details>
<summary>Downsides preview</summary>
<br/>

**IntelliSense:**
![image](https://user-images.githubusercontent.com/25330882/156400007-3cbbfc3d-036f-4bdd-8d45-74751e3eb983.png)

**TSDoc:**
![image](https://user-images.githubusercontent.com/25330882/156400570-80cfa701-2803-457b-9ef5-090b2a107b8e.png)

**`"length"` is a thumbnail name case:**
![image](https://user-images.githubusercontent.com/25330882/156400367-0a3c9abb-564f-470f-a3fc-7d44d265f52f.png)
![image](https://user-images.githubusercontent.com/25330882/156400444-faa74b65-8fa2-4108-90bf-588550211832.png)

</details>

Feel free to search for a better workaround if you feel like to, I'm running out of ideas here :/

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #30

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
