### PR TITLE
fix: add `@deprecated` tag to `slugs` document property

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -50,6 +50,10 @@ export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 	last_publication_date: string;
 	/**
 	 * Slugs associated with document.
+	 *
+	 * @deprecated Slugs are a deprecated feature used before the UID field was
+	 *   introduced. Migrate to the UID field. For more details, see
+	 *   https://community.prismic.io/t/what-are-slugs/6493
 	 */
 	slugs: string[];
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `@deprecated` tag to the `slugs` property on `PrismicDocument`.

Slugs are a deprecated featured used before the [UID field](https://prismic.io/docs/core-concepts/uid) was introduced. The property will continue to be included in the Rest API response, but usage should be discontinued and migrated to the UID field.

For more details on the `slugs` property and their deprecation decision, see: https://community.prismic.io/t/what-are-slugs/6493

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦤
