### PR TITLE
fix: correct `IntegrationFields` to not use the Integration Fields API shape

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -781,23 +781,14 @@ export type GroupField<
 /**
  * Integration Fields for Custom APIs
  *
- * @typeParam Blob - Data from the integrated API.
+ * @typeParam Data - Data from the integrated API.
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/core-concepts/integration-fields-setup}
  */
 export type IntegrationFields<
-	Blob = unknown,
+	Data extends Record<string, unknown> = Record<string, unknown>,
 	State extends FieldState = FieldState,
-> = State extends "empty"
-	? null
-	: {
-			id: string;
-			title?: string;
-			description?: string;
-			image_url?: string;
-			last_update: number;
-			blob: Blob;
-	  };
+> = State extends "empty" ? null : Data;
 
 /**
  * Slice - Sections of your website

--- a/test/fields-integrationFields.types.ts
+++ b/test/fields-integrationFields.types.ts
@@ -22,30 +22,15 @@ import * as prismicT from "../src";
  * Filled state.
  */
 expectType<prismicT.IntegrationFields>({
-	id: "string",
-	title: "string",
-	description: "string",
-	image_url: "string",
-	last_update: 0,
-	blob: null,
+	foo: "bar",
 });
-expectType<prismicT.IntegrationFields<unknown, "filled">>({
-	id: "string",
-	title: "string",
-	description: "string",
-	image_url: "string",
-	last_update: 0,
-	blob: null,
+expectType<prismicT.IntegrationFields<Record<string, unknown>, "filled">>({
+	foo: "bar",
 });
-expectType<prismicT.IntegrationFields<unknown, "empty">>(
+expectType<prismicT.IntegrationFields<Record<string, unknown>, "empty">>(
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	{
-		id: "string",
-		title: "string",
-		description: "string",
-		image_url: "string",
-		last_update: 0,
-		blob: null,
+		foo: "bar",
 	},
 );
 
@@ -53,8 +38,8 @@ expectType<prismicT.IntegrationFields<unknown, "empty">>(
  * Empty state.
  */
 expectType<prismicT.IntegrationFields>(null);
-expectType<prismicT.IntegrationFields<unknown, "empty">>(null);
-expectType<prismicT.IntegrationFields<unknown, "filled">>(
+expectType<prismicT.IntegrationFields<Record<string, unknown>, "empty">>(null);
+expectType<prismicT.IntegrationFields<Record<string, unknown>, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	null,
 );
@@ -63,21 +48,9 @@ expectType<prismicT.IntegrationFields<unknown, "filled">>(
  * Supports custom blob type.
  */
 expectType<prismicT.IntegrationFields<{ foo: "bar" }>>({
-	id: "string",
-	title: "string",
-	description: "string",
-	image_url: "string",
-	last_update: 0,
-	blob: {
-		foo: "bar",
-	},
+	foo: "bar",
 });
 expectType<prismicT.IntegrationFields<{ foo: "bar" }>>({
-	id: "string",
-	title: "string",
-	description: "string",
-	image_url: "string",
-	last_update: 0,
 	// @ts-expect-error - Blob should match the given type.
-	blob: null,
+	baz: "qux",
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes the `IntegrationFields` type to use the correct shape. Integration Fields data from Prismic's Rest API V2 provides the field's third-party data without any additional wrappers or nesting.

Before this PR, the `IntegrationFields` type incorrectly was shaped after the Integration Fields API.

For more details, see #38.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦙
