### PR TITLE
fix: add `imageUrl` to `SharedSliceModelVariation`

### DIFF
--- a/src/customType.ts
+++ b/src/customType.ts
@@ -557,4 +557,5 @@ export interface SharedSliceModelVariation<
 	description: string;
 	primary: PrimaryFields;
 	items: ItemFields;
+	imageUrl: string;
 }

--- a/test/customType-sharedSliceModel.types.ts
+++ b/test/customType-sharedSliceModel.types.ts
@@ -46,6 +46,7 @@ expectType<prismicT.SharedSliceModel>({
 					},
 				},
 			},
+			imageUrl: "string",
 		},
 	],
 });
@@ -88,6 +89,7 @@ expectType<
 			description: "string",
 			primary: {},
 			items: {},
+			imageUrl: "string",
 		},
 		{
 			// @ts-expect-error - Slice must match the given type.
@@ -98,6 +100,7 @@ expectType<
 			description: "string",
 			primary: {},
 			items: {},
+			imageUrl: "string",
 		},
 	],
 });

--- a/test/customType-sharedSliceModelVariation.types.ts
+++ b/test/customType-sharedSliceModelVariation.types.ts
@@ -40,6 +40,7 @@ expectType<prismicT.SharedSliceModelVariation>({
 			},
 		},
 	},
+	imageUrl: "string",
 });
 
 /**
@@ -53,6 +54,7 @@ expectType<prismicT.SharedSliceModelVariation<"foo">>({
 	description: "string",
 	primary: {},
 	items: {},
+	imageUrl: "string",
 });
 expectType<prismicT.SharedSliceModelVariation<"foo">>({
 	// @ts-expect-error - Slice ID must match the given ID.
@@ -63,6 +65,7 @@ expectType<prismicT.SharedSliceModelVariation<"foo">>({
 	description: "string",
 	primary: {},
 	items: {},
+	imageUrl: "string",
 });
 
 /**
@@ -95,6 +98,7 @@ expectType<
 		},
 	},
 	items: {},
+	imageUrl: "string",
 });
 
 /**
@@ -128,4 +132,5 @@ expectType<
 			},
 		},
 	},
+	imageUrl: "string",
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a missing `imageUrl` property to `SharedSliceModelVariation`. This property holds a URL to a model's preview image (usually a screenshot).

Closes #41

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
