### PR TITLE
feat: simplify `ImageField`

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -333,6 +333,17 @@ export interface EmptyImageFieldImage {
 }
 
 /**
+ * Useful to flatten the type output to improve type hints shown in editors. And
+ * also to transform an interface into a type to aide with assignability.
+ *
+ * Taken from the `type-fest` package.
+ *
+ * @typeParam T - The type to simplify.
+ * @see https://github.com/sindresorhus/type-fest/blob/cbd7ec510bd136ac045bbc74e391ee686b8a9a2f/source/simplify.d.ts
+ */
+type Simplify<T> = { [P in keyof T]: T[P] };
+
+/**
  * Image Field
  *
  * @typeParam ThumbnailNames - Names of thumbnails. If the field does not
@@ -343,11 +354,13 @@ export interface EmptyImageFieldImage {
 export type ImageField<
 	ThumbnailNames extends string = never,
 	State extends FieldState = FieldState,
-> = ImageFieldImage<State> &
-	Record<
-		Exclude<ThumbnailNames, keyof ImageFieldImage>,
-		ImageFieldImage<State>
-	>;
+> = Simplify<
+	ImageFieldImage<State> &
+		Record<
+			Exclude<ThumbnailNames, keyof ImageFieldImage>,
+			ImageFieldImage<State>
+		>
+>;
 
 // Links
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -333,17 +333,6 @@ export interface EmptyImageFieldImage {
 }
 
 /**
- * Useful to flatten the type output to improve type hints shown in editors. And
- * also to transform an interface into a type to aide with assignability.
- *
- * Taken from the `type-fest` package.
- *
- * @typeParam T - The type to simplify.
- * @see https://github.com/sindresorhus/type-fest/blob/cbd7ec510bd136ac045bbc74e391ee686b8a9a2f/source/simplify.d.ts
- */
-type Simplify<T> = { [P in keyof T]: T[P] };
-
-/**
  * Image Field
  *
  * @typeParam ThumbnailNames - Names of thumbnails. If the field does not
@@ -352,17 +341,13 @@ type Simplify<T> = { [P in keyof T]: T[P] };
  * @see Image field documentation: {@link https://prismic.io/docs/core-concepts/image}
  */
 export type ImageField<
-	ThumbnailNames extends string | null = never,
+	ThumbnailNames extends string = never,
 	State extends FieldState = FieldState,
-> = Simplify<
-	ImageFieldImage<State> &
-		Record<
-			ThumbnailNames extends string
-				? Exclude<ThumbnailNames, keyof ImageFieldImage>
-				: never,
-			ImageFieldImage<State>
-		>
->;
+> = ImageFieldImage<State> &
+	Record<
+		Exclude<ThumbnailNames, keyof ImageFieldImage>,
+		ImageFieldImage<State>
+	>;
 
 // Links
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -346,18 +346,24 @@ type Simplify<T> = { [P in keyof T]: T[P] };
 /**
  * Image Field
  *
+ * **Note**: Passing `null` to the `ThumbnailNames` parameter is deprecated and
+ * will be removed in a future version. Use `never` instead.
+ *
  * @typeParam ThumbnailNames - Names of thumbnails. If the field does not
- *   contain thumbnails, `null` can be used to "disable" thumbnail fields.
+ *   contain thumbnails, `never` can be used to "disable" thumbnail fields.
  * @typeParam State - State of the field which determines its shape.
  * @see Image field documentation: {@link https://prismic.io/docs/core-concepts/image}
  */
 export type ImageField<
-	ThumbnailNames extends string = never,
+	// `null` is included for backwards compatibility with older versions of
+	// this package. `null` should be treated as deprecated. `never` is
+	// preferred.
+	ThumbnailNames extends string | null = never,
 	State extends FieldState = FieldState,
 > = Simplify<
 	ImageFieldImage<State> &
 		Record<
-			Exclude<ThumbnailNames, keyof ImageFieldImage>,
+			Exclude<Extract<ThumbnailNames, string>, keyof ImageFieldImage>,
 			ImageFieldImage<State>
 		>
 >;

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -139,6 +139,30 @@ withoutThumbnails.Foo;
 // @ts-expect-error - No thumbnails should be included when set to `never`.
 withoutThumbnails.Bar;
 
+// TODO: Remove this group of tests when support for `null` ThumbnailNames is
+// removed.
+/**
+ * Thumbnails can be disabled with `null` ThumbnailNames.
+ */
+expectType<prismicT.ImageField<null>>({
+	url: "url",
+	dimensions: { width: 1, height: 1 },
+	alt: null,
+	copyright: null,
+	// @ts-expect-error - No thumbnails should be included when set to `null`.
+	Foo: {
+		url: "url",
+		dimensions: { width: 1, height: 1 },
+		alt: "alt",
+		copyright: "copyright",
+	},
+});
+const withoutThumbnailsNull = {} as prismicT.ImageField<null>;
+// @ts-expect-error - No thumbnails should be included when set to `null`.
+withoutThumbnailsNull.Foo;
+// @ts-expect-error - No thumbnails should be included when set to `null`.
+withoutThumbnailsNull.Bar;
+
 /**
  * Thumbnail name can be `"length"` (edge case, see: #31)
  */

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -27,13 +27,13 @@ expectType<prismicT.ImageField>({
 	alt: "alt",
 	copyright: "copyright",
 });
-expectType<prismicT.ImageField<null, "filled">>({
+expectType<prismicT.ImageField<never, "filled">>({
 	url: "url",
 	dimensions: { width: 1, height: 1 },
 	alt: "alt",
 	copyright: "copyright",
 });
-expectType<prismicT.ImageField<null, "empty">>({
+expectType<prismicT.ImageField<never, "empty">>({
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	url: "url",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
@@ -54,13 +54,13 @@ expectType<prismicT.ImageField>({
 	copyright: null,
 });
 expectType<prismicT.ImageField>({});
-expectType<prismicT.ImageField<null, "empty">>({
+expectType<prismicT.ImageField<never, "empty">>({
 	url: null,
 	dimensions: null,
 	alt: null,
 	copyright: null,
 });
-expectType<prismicT.ImageField<null, "filled">>({
+expectType<prismicT.ImageField<never, "filled">>({
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	url: null,
 	// @ts-expect-error - Filled fields cannot contain an empty value.
@@ -120,7 +120,7 @@ withThumbnails.Bar;
 /**
  * Thumbnails can be disabled with `null` ThumbnailNames.
  */
-expectType<prismicT.ImageField<null>>({
+expectType<prismicT.ImageField<never>>({
 	url: "url",
 	dimensions: { width: 1, height: 1 },
 	alt: null,
@@ -133,7 +133,7 @@ expectType<prismicT.ImageField<null>>({
 		copyright: "copyright",
 	},
 });
-const withoutThumbnails = {} as prismicT.ImageField<null>;
+const withoutThumbnails = {} as prismicT.ImageField<never>;
 // @ts-expect-error - No thumbnails should be included when set to `null`.
 withoutThumbnails.Foo;
 // @ts-expect-error - No thumbnails should be included when set to `null`.
@@ -172,7 +172,7 @@ expectType<prismicT.ImageField<"length">>({
  * ImageFields are valid ImageFieldImage extends.
  */
 expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField>>(true);
-expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<null>>>(true);
+expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<never>>>(true);
 expectType<TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<"Foo">>>(true);
 expectType<
 	TypeOf<prismicT.ImageFieldImage, prismicT.ImageField<"Foo" | "Bar">>
@@ -184,7 +184,7 @@ const _ImageFieldIsValidImageFieldImageExtendDebug: prismicT.ImageFieldImage =
  * ImageFieldImages are valid ImageField extends with no thumbnails.
  */
 expectType<TypeOf<prismicT.ImageField, prismicT.ImageFieldImage>>(true);
-expectType<TypeOf<prismicT.ImageField<null>, prismicT.ImageFieldImage>>(true);
+expectType<TypeOf<prismicT.ImageField<never>, prismicT.ImageFieldImage>>(true);
 expectType<TypeOf<prismicT.ImageField<"Foo">, prismicT.ImageFieldImage>>(false);
 expectType<
 	TypeOf<prismicT.ImageField<"Foo" | "Bar">, prismicT.ImageFieldImage>

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -118,14 +118,14 @@ withThumbnails.Foo;
 withThumbnails.Bar;
 
 /**
- * Thumbnails can be disabled with `null` ThumbnailNames.
+ * Thumbnails can be disabled with `never` ThumbnailNames.
  */
 expectType<prismicT.ImageField<never>>({
 	url: "url",
 	dimensions: { width: 1, height: 1 },
 	alt: null,
 	copyright: null,
-	// @ts-expect-error - No thumbnails should be included when set to `null`.
+	// @ts-expect-error - No thumbnails should be included when set to `never`.
 	Foo: {
 		url: "url",
 		dimensions: { width: 1, height: 1 },
@@ -134,9 +134,9 @@ expectType<prismicT.ImageField<never>>({
 	},
 });
 const withoutThumbnails = {} as prismicT.ImageField<never>;
-// @ts-expect-error - No thumbnails should be included when set to `null`.
+// @ts-expect-error - No thumbnails should be included when set to `never`.
 withoutThumbnails.Foo;
-// @ts-expect-error - No thumbnails should be included when set to `null`.
+// @ts-expect-error - No thumbnails should be included when set to `never`.
 withoutThumbnails.Bar;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR simplifies `ImageField` by changing how it uses handles `ThumbnailNames` when given `null` as its value.

### Deprecating `null` in `ThumbnailNames`

As of this PR, `ImageField<never>` is the preferred method to type an Image field without thumbnails. `ImageField<null>` will continue to work, but **`null` is now depreacted**.

### Reason for the change

`@prismicio/helpers`'s use of `ImageField` in its `isFilled.image()` helper resulted in a broken `index.d.ts` file in `@prismicio/helpers`. The compiled type declaration file, bundled by `rollup-plugin-dts`, included invalid types.

See the following issues for more details:
- prismicio/prismic-client#252
- prismicio/prismic-helpers#55

The simplification made in this PR removes the invalid generated code in `@prismicio/helpers` and `@prismicio/client`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐻‍❄️
