### PR TITLE
fix: allow `ContentRelationshipField`'s `data` property to be overrided

### DIFF
--- a/src/value/contentRelationship.ts
+++ b/src/value/contentRelationship.ts
@@ -15,10 +15,9 @@ import type { SliceZone } from "./sliceZone";
 export type ContentRelationshipField<
 	TypeEnum = string,
 	LangEnum = string,
-	DataInterface extends Record<
-		string,
-		AnyRegularField | GroupField | SliceZone
-	> = never,
+	DataInterface extends
+		| Record<string, AnyRegularField | GroupField | SliceZone>
+		| unknown = unknown,
 	State extends FieldState = FieldState,
 > = State extends "empty"
 	? EmptyLinkField<typeof LinkType.Document>
@@ -30,10 +29,9 @@ export type ContentRelationshipField<
 export interface FilledContentRelationshipField<
 	TypeEnum = string,
 	LangEnum = string,
-	DataInterface extends Record<
-		string,
-		AnyRegularField | GroupField | SliceZone
-	> = never,
+	DataInterface extends
+		| Record<string, AnyRegularField | GroupField | SliceZone>
+		| unknown = unknown,
 > {
 	link_type: typeof LinkType.Document;
 	id: string;

--- a/src/value/link.ts
+++ b/src/value/link.ts
@@ -46,10 +46,9 @@ export interface FilledLinkToWebField {
 export type LinkField<
 	TypeEnum = string,
 	LangEnum = string,
-	DataInterface extends Record<
-		string,
-		AnyRegularField | GroupField | SliceZone
-	> = never,
+	DataInterface extends
+		| Record<string, AnyRegularField | GroupField | SliceZone>
+		| unknown = unknown,
 	State extends FieldState = FieldState,
 > = State extends "empty"
 	? EmptyLinkField<typeof LinkType.Any>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows `ContentRelationshipField`'s `data` property to be overrided.

The type contains a `DataInterface` type parameter that defaults to `never`. This design is not a problem when providing the data interface as a type parameter (i.e. `ContentRelationshipField<string, string, { foo: "bar" }>`), but it is a problem when using type intersection. Intersecting with `never` always results in `never`, regardless of the other intersecting type.

This PR changes `DataInterface`'s default value from `never` to `unknown`. This signals that the `data` property's value is unknown (possibly `undefined`) until it is defined. It should behave similarly to using `never`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
