### PR TITLE
fix: backport `IntegrationFields` to `IntegrationField` rename from `@prismicio/client` v7

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 // NOTE: The GraphQL exports are purposely not included in the root-level API.
 // Instead, they are provided under their own `/graphql` entry.
 
+// Imports are used for deprecations.
+import type { CustomTypeModelIntegrationField } from "./model/integration";
+import type { IntegrationField } from "./value/integration";
+
 //=============================================================================
 // Value - Types representing Prismic document and field values.
 //=============================================================================
@@ -99,7 +103,12 @@ export type { SelectField } from "./value/select";
 export type { TimestampField } from "./value/timestamp";
 export type { GeoPointField } from "./value/geoPoint";
 
-export type { IntegrationFields } from "./value/integrationFields";
+/**
+ * @deprecated Renamed to `IntegrationField`
+ */
+// TODO: Remove when we remove support for deprecated `IntegrationFields` export.
+type IntegrationFields = IntegrationField;
+export { IntegrationField, IntegrationFields };
 
 export type { GroupField } from "./value/group";
 
@@ -153,7 +162,15 @@ export type { CustomTypeModelSelectField } from "./model/select";
 export type { CustomTypeModelTimestampField } from "./model/timestamp";
 export type { CustomTypeModelGeoPointField } from "./model/geoPoint";
 
-export type { CustomTypeModelIntegrationFieldsField } from "./model/integrationFields";
+/**
+ * @deprecated Renamed to `CustomTypeModelIntegrationField`.
+ */
+// TODO: Remove when we remove support for deprecated `CustomTypeModelIntegrationField` export.
+type CustomTypeModelIntegrationFieldsField = CustomTypeModelIntegrationField;
+export {
+	CustomTypeModelIntegrationField,
+	CustomTypeModelIntegrationFieldsField,
+};
 export type { CustomTypeModelGroupField } from "./model/group";
 export type {
 	CustomTypeModelSliceZoneField,

--- a/src/model/integration.ts
+++ b/src/model/integration.ts
@@ -5,8 +5,8 @@ import type { CustomTypeModelFieldType } from "./types";
  *
  * More details: {@link https://prismic.io/docs/core-concepts/integration-fields}
  */
-export interface CustomTypeModelIntegrationFieldsField {
-	type: typeof CustomTypeModelFieldType.IntegrationFields;
+export interface CustomTypeModelIntegrationField {
+	type: typeof CustomTypeModelFieldType.Integration;
 	config?: {
 		label?: string | null;
 		placeholder?: string;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -15,7 +15,7 @@ import type { CustomTypeModelSelectField } from "./select";
 import type { CustomTypeModelTimestampField } from "./timestamp";
 import type { CustomTypeModelGeoPointField } from "./geoPoint";
 
-import type { CustomTypeModelIntegrationFieldsField } from "./integrationFields";
+import type { CustomTypeModelIntegrationField } from "./integration";
 import type { CustomTypeModelGroupField } from "./group";
 import type { CustomTypeModelSliceZoneField } from "./sliceZone";
 
@@ -35,7 +35,7 @@ export const CustomTypeModelFieldType = {
 	GeoPoint: "GeoPoint",
 	Group: "Group",
 	Image: "Image",
-	IntegrationFields: "IntegrationFields",
+	Integration: "IntegrationFields",
 	Link: "Link",
 	Number: "Number",
 	Select: "Select",
@@ -44,6 +44,10 @@ export const CustomTypeModelFieldType = {
 	Text: "Text",
 	Timestamp: "Timestamp",
 	UID: "UID",
+	/**
+	 * @deprecated - Renamed to `Integration`.
+	 */
+	IntegrationFields: "IntegrationFields",
 	/**
 	 * @deprecated - Legacy field type. Use `Number` instead.
 	 */
@@ -77,7 +81,7 @@ export type CustomTypeModelFieldForGroup =
 	| CustomTypeModelEmbedField
 	| CustomTypeModelGeoPointField
 	| CustomTypeModelImageField
-	| CustomTypeModelIntegrationFieldsField
+	| CustomTypeModelIntegrationField
 	| CustomTypeModelContentRelationshipField
 	| CustomTypeModelLinkField
 	| CustomTypeModelLinkToMediaField

--- a/src/value/integration.ts
+++ b/src/value/integration.ts
@@ -7,7 +7,7 @@ import type { FieldState } from "./types";
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/core-concepts/integration-fields-setup}
  */
-export type IntegrationFields<
+export type IntegrationField<
 	Data extends Record<string, unknown> = Record<string, unknown>,
 	State extends FieldState = FieldState,
 > = State extends "empty" ? null : Data;

--- a/src/value/types.ts
+++ b/src/value/types.ts
@@ -15,7 +15,7 @@ import type { SelectField } from "./select";
 import type { TimestampField } from "./timestamp";
 import type { GeoPointField } from "./geoPoint";
 
-import type { IntegrationFields } from "./integrationFields";
+import type { IntegrationField } from "./integration";
 
 /**
  * Empty state for object-shaped fields.
@@ -46,7 +46,7 @@ export type AnyRegularField =
 	| SelectField
 	| BooleanField
 	| GeoPointField
-	| IntegrationFields;
+	| IntegrationField;
 
 /**
  * Useful to flatten the type output to improve type hints shown in editors. And

--- a/test/customType-integration.types.ts
+++ b/test/customType-integration.types.ts
@@ -4,7 +4,7 @@ import * as prismicTI from "@prismicio/types-internal";
 
 import * as prismicT from "../src";
 
-(value: prismicT.CustomTypeModelIntegrationFieldsField): true => {
+(value: prismicT.CustomTypeModelIntegrationField): true => {
 	switch (typeof value) {
 		case "object": {
 			if (value === null) {
@@ -20,8 +20,8 @@ import * as prismicT from "../src";
 	}
 };
 
-expectType<prismicT.CustomTypeModelIntegrationFieldsField>({
-	type: prismicT.CustomTypeModelFieldType.IntegrationFields,
+expectType<prismicT.CustomTypeModelIntegrationField>({
+	type: prismicT.CustomTypeModelFieldType.Integration,
 	config: {
 		label: "string",
 		catalog: "string",
@@ -31,8 +31,8 @@ expectType<prismicT.CustomTypeModelIntegrationFieldsField>({
 /**
  * Supports optional placeholder.
  */
-expectType<prismicT.CustomTypeModelIntegrationFieldsField>({
-	type: prismicT.CustomTypeModelFieldType.IntegrationFields,
+expectType<prismicT.CustomTypeModelIntegrationField>({
+	type: prismicT.CustomTypeModelFieldType.Integration,
 	config: {
 		label: "string",
 		placeholder: "string",
@@ -43,7 +43,7 @@ expectType<prismicT.CustomTypeModelIntegrationFieldsField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismicT.CustomTypeModelIntegrationFieldsField>(
+expectType<prismicT.CustomTypeModelIntegrationField>(
 	{} as prismicTI.CustomTypes.Widgets.Nestable.IntegrationField,
 );
 
@@ -51,5 +51,5 @@ expectType<prismicT.CustomTypeModelIntegrationFieldsField>(
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
 expectType<prismicTI.CustomTypes.Widgets.Nestable.IntegrationField>(
-	{} as prismicT.CustomTypeModelIntegrationFieldsField,
+	{} as prismicT.CustomTypeModelIntegrationField,
 );

--- a/test/customType.types.ts
+++ b/test/customType.types.ts
@@ -240,7 +240,7 @@ expectType<
 expectType<
 	TypeOf<
 		prismicT.CustomTypeModelFieldForGroup,
-		prismicT.CustomTypeModelIntegrationFieldsField
+		prismicT.CustomTypeModelIntegrationField
 	>
 >(true);
 expectType<

--- a/test/fields-integration.types.ts
+++ b/test/fields-integration.types.ts
@@ -2,7 +2,7 @@ import { expectType, expectNever } from "ts-expect";
 
 import * as prismicT from "../src";
 
-(value: prismicT.IntegrationFields): true => {
+(value: prismicT.IntegrationField): true => {
 	switch (typeof value) {
 		case "object": {
 			if (value === null) {
@@ -21,13 +21,13 @@ import * as prismicT from "../src";
 /**
  * Filled state.
  */
-expectType<prismicT.IntegrationFields>({
+expectType<prismicT.IntegrationField>({
 	foo: "bar",
 });
-expectType<prismicT.IntegrationFields<Record<string, unknown>, "filled">>({
+expectType<prismicT.IntegrationField<Record<string, unknown>, "filled">>({
 	foo: "bar",
 });
-expectType<prismicT.IntegrationFields<Record<string, unknown>, "empty">>(
+expectType<prismicT.IntegrationField<Record<string, unknown>, "empty">>(
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	{
 		foo: "bar",
@@ -37,9 +37,9 @@ expectType<prismicT.IntegrationFields<Record<string, unknown>, "empty">>(
 /**
  * Empty state.
  */
-expectType<prismicT.IntegrationFields>(null);
-expectType<prismicT.IntegrationFields<Record<string, unknown>, "empty">>(null);
-expectType<prismicT.IntegrationFields<Record<string, unknown>, "filled">>(
+expectType<prismicT.IntegrationField>(null);
+expectType<prismicT.IntegrationField<Record<string, unknown>, "empty">>(null);
+expectType<prismicT.IntegrationField<Record<string, unknown>, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	null,
 );
@@ -47,10 +47,10 @@ expectType<prismicT.IntegrationFields<Record<string, unknown>, "filled">>(
 /**
  * Supports custom blob type.
  */
-expectType<prismicT.IntegrationFields<{ foo: "bar" }>>({
+expectType<prismicT.IntegrationField<{ foo: "bar" }>>({
 	foo: "bar",
 });
-expectType<prismicT.IntegrationFields<{ foo: "bar" }>>({
+expectType<prismicT.IntegrationField<{ foo: "bar" }>>({
 	// @ts-expect-error - Blob should match the given type.
 	baz: "qux",
 });

--- a/test/fields.types.ts
+++ b/test/fields.types.ts
@@ -27,7 +27,7 @@ expectType<TypeOf<prismicT.AnyRegularField, prismicT.DateField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.EmbedField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.GeoPointField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.ImageField>>(true);
-expectType<TypeOf<prismicT.AnyRegularField, prismicT.IntegrationFields>>(true);
+expectType<TypeOf<prismicT.AnyRegularField, prismicT.IntegrationField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.KeyTextField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.LinkField>>(true);
 expectType<TypeOf<prismicT.AnyRegularField, prismicT.LinkToMediaField>>(true);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,6 +53,7 @@ test("custom type field type mapping", () => {
 		GeoPoint: "GeoPoint",
 		Group: "Group",
 		Image: "Image",
+		Integration: "IntegrationFields",
 		IntegrationFields: "IntegrationFields",
 		Link: "Link",
 		Number: "Number",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR backports the `IntegrationFields` to `IntegrationField` rename from `@prismicio/client` v7.

Although `@prismicio/types` package is now deprecated and replaced by `@prismicio/client`, projects may still be using this package. `prismic-ts-codegen` is compatbile with `@prismicio/types` and `@prismicio/client`, which requires extra internal logic to change implementations dependning on which types provider is used. By backporting the integration field rename, `prismic-ts-codegen`'s implementation can be simpler.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦭
