### PR TITLE
feat: backport extended media API response

### DIFF
--- a/src/value/image.ts
+++ b/src/value/image.ts
@@ -11,18 +11,27 @@ export type ImageFieldImage<State extends FieldState = FieldState> =
 	State extends "empty" ? EmptyImageFieldImage : FilledImageFieldImage;
 
 export interface FilledImageFieldImage {
+	id: string;
 	url: string;
 	dimensions: {
 		width: number;
 		height: number;
+	};
+	edit: {
+		x: number;
+		y: number;
+		zoom: number;
+		background: string;
 	};
 	alt: string | null;
 	copyright: string | null;
 }
 
 export interface EmptyImageFieldImage {
+	id?: null;
 	url?: null;
 	dimensions?: null;
+	edit?: null;
 	alt?: null;
 	copyright?: null;
 }

--- a/src/value/linkToMedia.ts
+++ b/src/value/linkToMedia.ts
@@ -15,6 +15,7 @@ export type LinkToMediaField<State extends FieldState = FieldState> =
  * Link that points to media
  */
 export interface FilledLinkToMediaField {
+	id: string;
 	link_type: typeof LinkType.Media;
 	name: string;
 	kind: string;

--- a/src/value/richText.ts
+++ b/src/value/richText.ts
@@ -152,12 +152,19 @@ export interface RTLabelNode extends RTSpanNodeBase {
  */
 export type RTImageNode = {
 	type: typeof RichTextNodeType.image;
+	id: string;
 	url: string;
 	alt: string | null;
 	copyright: string | null;
 	dimensions: {
 		width: number;
 		height: number;
+	};
+	edit: {
+		x: number;
+		y: number;
+		zoom: number;
+		background: string;
 	};
 	linkTo?:
 		| FilledContentRelationshipField

--- a/test/fields-image.types.ts
+++ b/test/fields-image.types.ts
@@ -22,22 +22,30 @@ import * as prismicT from "../src";
  * Filled state.
  */
 expectType<prismicT.ImageField>({
+	id: "id",
 	url: "url",
 	dimensions: { width: 1, height: 1 },
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
 });
 expectType<prismicT.ImageField<never, "filled">>({
+	id: "id",
 	url: "url",
 	dimensions: { width: 1, height: 1 },
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
 });
 expectType<prismicT.ImageField<never, "empty">>({
+	// @ts-expect-error - Empty fields cannot contain an empty value.
+	id: "id",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	url: "url",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	dimensions: { width: 1, height: 1 },
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	alt: "alt",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
@@ -62,9 +70,13 @@ expectType<prismicT.ImageField<never, "empty">>({
 });
 expectType<prismicT.ImageField<never, "filled">>({
 	// @ts-expect-error - Filled fields cannot contain an empty value.
+	id: null,
+	// @ts-expect-error - Filled fields cannot contain an empty value.
 	url: null,
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	dimensions: null,
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	edit: null,
 	alt: null,
 	copyright: null,
 });
@@ -73,8 +85,10 @@ expectType<prismicT.ImageField<never, "filled">>({
  * Allows null alt and copyright.
  */
 expectType<prismicT.ImageField>({
+	id: "id",
 	url: "url",
 	dimensions: { width: 1, height: 1 },
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: null,
 	copyright: null,
 });
@@ -95,19 +109,25 @@ expectType<prismicT.ImageField>({
  * Supports thumbnails.
  */
 expectType<prismicT.ImageField<"Foo" | "Bar">>({
+	id: "id",
 	url: "url",
 	dimensions: { width: 1, height: 1 },
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
 	Foo: {
+		id: "id",
 		url: "url",
 		dimensions: { width: 1, height: 1 },
+		edit: { x: 0, y: 0, zoom: 1, background: "background" },
 		alt: "alt",
 		copyright: "copyright",
 	},
 	Bar: {
+		id: "id",
 		url: "url",
 		dimensions: { width: 1, height: 1 },
+		edit: { x: 0, y: 0, zoom: 1, background: "background" },
 		alt: "alt",
 		copyright: "copyright",
 	},
@@ -180,13 +200,17 @@ expectType<prismicT.ImageField>({
 	},
 });
 expectType<prismicT.ImageField<"length">>({
+	id: "id",
 	url: "url",
 	dimensions: { width: 1, height: 1 },
+	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
 	length: {
+		id: "id",
 		url: "url",
 		dimensions: { width: 1, height: 1 },
+		edit: { x: 0, y: 0, zoom: 1, background: "background" },
 		alt: "alt",
 		copyright: "copyright",
 	},

--- a/test/fields-linkToMedia.types.ts
+++ b/test/fields-linkToMedia.types.ts
@@ -23,6 +23,7 @@ import * as prismicT from "../src";
  */
 expectType<prismicT.LinkToMediaField>({
 	link_type: prismicT.LinkType.Media,
+	id: "string",
 	name: "string",
 	kind: "string",
 	url: "string",
@@ -32,6 +33,7 @@ expectType<prismicT.LinkToMediaField>({
 });
 expectType<prismicT.LinkToMediaField<"filled">>({
 	link_type: prismicT.LinkType.Media,
+	id: "string",
 	name: "string",
 	kind: "string",
 	url: "string",
@@ -42,6 +44,7 @@ expectType<prismicT.LinkToMediaField<"filled">>({
 expectType<prismicT.LinkToMediaField<"empty">>({
 	link_type: prismicT.LinkType.Media,
 	// @ts-expect-error - Empty fields cannot contain a filled value.
+	id: "string",
 	name: "string",
 	kind: "string",
 	url: "string",

--- a/test/fields-richText.types.ts
+++ b/test/fields-richText.types.ts
@@ -116,6 +116,7 @@ expectType<prismicT.RichTextField>([
 	{ type: prismicT.RichTextNodeType.oListItem, text: "string", spans: [] },
 	{
 		type: prismicT.RichTextNodeType.image,
+		id: "string",
 		alt: "string",
 		url: "string",
 		copyright: "string",
@@ -123,6 +124,7 @@ expectType<prismicT.RichTextField>([
 			width: 0,
 			height: 0,
 		},
+		edit: { x: 0, y: 0, zoom: 1, background: "background" },
 		linkTo: {
 			link_type: prismicT.LinkType.Web,
 			url: "string",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Related: https://github.com/prismicio/prismic-web/pull/134

@prismicio/react still relies on @prismicio/richtext which relies on @prismicio/types. This makes types expected from @prismicio/react inconsistent with types generated from @prismicio/client. This PR backports new media API response types for types to match (which perhaps also solves other problems)

In the near future I think we'll need a plan to update @prismicio/react not to use @prismicio/richtext anymore but @prismicio/client/richtext instead (which was my plan first, but I wasn't sure how you wanted to handle the peer dependency of @prismicio/client then as I don't think it can be promoted to a regular dependency there? (that's how it's done with Vue.js though 🤷‍♀️)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
